### PR TITLE
[FEAT] 오늘의 미션 관련 API 컨트롤러 테스트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ application-local.yml
 application.yml
 application-test.yml
 
+firebase-ignore.json
+
 **.adoc
 **.http
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	testImplementation "com.epages:restdocs-api-spec-mockmvc:${restdocsApiSpecVersion}"
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'io.rest-assured:rest-assured'
+	swaggerUI 'org.webjars:swagger-ui:4.11.1'
 
 	// AWS sdk
 	implementation("software.amazon.awssdk:bom:2.21.0")
@@ -125,18 +127,40 @@ tasks.named('test') {
 
 tasks.withType(GenerateSwaggerUI) {
 	dependsOn 'openapi3'
+	doFirst {
+		def swaggerUIFile = file("${openapi3.outputDirectory}/api-spec/openapi3.yaml")
+		def securitySchemesContent =  "  securitySchemes:\n" +  \
+                                      "    APIKey:\n" +  \
+                                      "      type: apiKey\n" +  \
+                                      "      name: Authorization\n" +  \
+                                      "      in: header\n" + \
+                                      "security:\n" +
+				"  - APIKey: []  # Apply the security scheme here"
+//		def existingContent = swaggerUIFile.text
+//		def updatedContent = existingContent + securitySchemesContent
+//		swaggerUIFile.write(updatedContent)
+		swaggerUIFile.append securitySchemesContent
+	}
 
 	// local 확인용으로 json 정적파일 복사
 //	delete file('src/main/resources/static/docs')
-	copy {
-		from "build/resources/main/static/docs"
-		into "src/main/resources/static/docs/"
-	}
+//	copy {
+//		from "build/resources/main/static/docs"
+//		into "src/main/resources/static/docs/"
+//	}
 }
 
 // openAPI 작성 자동화 => 패키징 전에 openapi3 태스크를 먼저 실행하도록 유발
 bootJar {
 	dependsOn(':openapi3')
+	dependsOn generateSwaggerUISample
+	from("${generateSwaggerUISample.outputDir}") {
+		into 'static/docs'
+	}
+//	copy {
+//		from "build/resources/main/static/docs"
+//		into "src/main/resources/static/docs/"
+//	}
 }
 
 openapi3 {

--- a/build.gradle
+++ b/build.gradle
@@ -143,20 +143,20 @@ tasks.withType(GenerateSwaggerUI) {
 	}
 
 	// local 확인용으로 json 정적파일 복사
-//	delete file('src/main/resources/static/docs')
-//	copy {
-//		from "build/resources/main/static/docs"
-//		into "src/main/resources/static/docs/"
-//	}
+	delete file('src/main/resources/static/docs')
+	copy {
+		from "build/resources/main/static/docs"
+		into "src/main/resources/static/docs/"
+	}
 }
 
 // openAPI 작성 자동화 => 패키징 전에 openapi3 태스크를 먼저 실행하도록 유발
 bootJar {
 	dependsOn(':openapi3')
-	dependsOn generateSwaggerUISample
-	from("${generateSwaggerUISample.outputDir}") {
-		into 'static/docs'
-	}
+//	dependsOn generateSwaggerUISample
+//	from("${generateSwaggerUISample.outputDir}") {
+//		into 'static/docs'
+//	}
 //	copy {
 //		from "build/resources/main/static/docs"
 //		into "src/main/resources/static/docs/"

--- a/src/main/java/sopt/org/motivooServer/domain/common/BaseTimeEntity.java
+++ b/src/main/java/sopt/org/motivooServer/domain/common/BaseTimeEntity.java
@@ -16,8 +16,8 @@ import lombok.Getter;
 public abstract class BaseTimeEntity {
 
 	@CreatedDate
-	private LocalDateTime createdAt;
+	protected LocalDateTime createdAt;
 
 	@LastModifiedDate
-	private LocalDateTime updatedAt;
+	protected LocalDateTime updatedAt;
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/controller/UserMissionController.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/controller/UserMissionController.java
@@ -52,7 +52,7 @@ public class UserMissionController {
 	}
 
 	@PostMapping("/today")
-	public ResponseEntity<ApiResponse> choiceTodayMission(@RequestBody final TodayMissionChoiceRequest request, final Principal principal) {
+	public ResponseEntity<ApiResponse<Object>> choiceTodayMission(@RequestBody final TodayMissionChoiceRequest request, final Principal principal) {
 		Long userMissionId = userMissionService.choiceTodayMission(request, getUserFromPrincipal(principal));
 		URI location = URI.create("/today" + userMissionId);
 

--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/MissionHistoryResponse.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/MissionHistoryResponse.java
@@ -43,7 +43,7 @@ public record MissionHistoryResponse(
 
 		return MissionHistoryResponse.builder()
 			.userType(user.getType().getValue())
-			.todayMission(TodayUserMissionDto.of(todayMission))
+			.todayMission(TodayUserMissionDto.ofHistory(todayMission))
 			.missionHistory(IntStream.range(0, myMissions.size())
 				.mapToObj(i -> ParentchildMissionDto.of(my.get(i), opponent.get(i)))
 				.collect(Collectors.toList()))

--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/TodayUserMissionDto.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/TodayUserMissionDto.java
@@ -25,6 +25,11 @@ public record TodayUserMissionDto(
 			.missionQuest(userMission.getMissionQuest().getContent()).build();
 	}
 
+	public static TodayUserMissionDto ofHistory(UserMission userMission) {
+		return TodayUserMissionDto.builder()
+			.missionContent(userMission.getMission().getContent()).build();
+	}
+
 	public static TodayUserMissionDto of(UserMissionChoices userMissionChoices) {
 		return TodayUserMissionDto.builder()
 			.missionId(userMissionChoices.getMission().getId())

--- a/src/main/java/sopt/org/motivooServer/domain/mission/entity/Mission.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/entity/Mission.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import sopt.org.motivooServer.domain.common.BaseTimeEntity;
@@ -47,4 +48,17 @@ public class Mission extends BaseTimeEntity {
 	@Column(columnDefinition = "TEXT")
 	private String iconUrl;
 
+	@Builder
+	private Mission(String content, String type, String healthNotes, int stepCount, String descriptionUrl,
+		UserType target,
+		String bodyPart, String iconUrl) {
+		this.content = content;
+		this.type = type;
+		this.healthNotes = healthNotes;
+		this.stepCount = stepCount;
+		this.descriptionUrl = descriptionUrl;
+		this.target = target;
+		this.bodyPart = bodyPart;
+		this.iconUrl = iconUrl;
+	}
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/entity/MissionQuest.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/entity/MissionQuest.java
@@ -5,11 +5,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import sopt.org.motivooServer.domain.common.BaseTimeEntity;
 
 @Getter
 @Entity
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class MissionQuest extends BaseTimeEntity {
 
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,4 +22,9 @@ public class MissionQuest extends BaseTimeEntity {
 
 	@Column(nullable = false)
 	private String content;
+
+	@Builder
+	private MissionQuest(String content) {
+		this.content = content;
+	}
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/entity/UserMission.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/entity/UserMission.java
@@ -1,5 +1,7 @@
 package sopt.org.motivooServer.domain.mission.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -60,6 +62,10 @@ public class UserMission extends BaseTimeEntity {
 		if (!user.getUserMissions().contains(this)) {
 			user.getUserMissions().add(this);
 		}
+	}
+
+	public void updateCreatedAt(LocalDateTime date) {
+		this.createdAt = date;
 	}
 
 	public void updateImgUrl(final String imgUrl) {

--- a/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
@@ -91,9 +91,13 @@ public class User extends BaseTimeEntity {
 		this.deleted = deleted;
 	}
 
-	//== Null 체크를 위한 유효성 검사 ==//
-	private void validateAge() {
-		Objects.requireNonNull(age, NULL_VALUE_AGE.message());
+	@Builder(builderMethodName = "builderInTest")
+	private User(Integer age, UserType type, String socialId, String nickname, SocialPlatform socialPlatform) {
+		this.age = age;
+		this.type = type;
+		this.socialId = socialId;
+		this.nickname = nickname;
+		this.socialPlatform = socialPlatform;
 	}
 
 
@@ -110,7 +114,6 @@ public class User extends BaseTimeEntity {
 	}
 
 	public void updateOnboardingInfo(UserType type, Integer age) {
-		validateAge();
 		this.type = type;
 		this.age = age;
 	}

--- a/src/main/java/sopt/org/motivooServer/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/config/swagger/SwaggerConfig.java
@@ -2,10 +2,13 @@ package sopt.org.motivooServer.global.config.swagger;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
@@ -18,9 +21,27 @@ public class SwaggerConfig {
 			.version("v1.0.0");
 
 		//TODO JWT 토큰 인증을 위한 SecurityScheme 설정 추가
+		// Security 스키마 설정
+		String jwtSchemeName = "jwtAuth";
+
+		// Security 요청 설정
+		SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+		SecurityScheme bearerAuth = new SecurityScheme()
+			.type(SecurityScheme.Type.HTTP)
+			.scheme("bearer")
+			.bearerFormat("JWT")
+			.in(SecurityScheme.In.HEADER)
+			.name(HttpHeaders.AUTHORIZATION);
+
+		Components components = new Components()
+			.addSecuritySchemes(jwtSchemeName, bearerAuth);
+
 
 		return new OpenAPI()
-			.components(new Components())
+			.components(components)
+			// API 마다 Security 인증 컴포넌트 설정
+			.addSecurityItem(securityRequirement)
 			.info(info);
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/healthcheck/SlackTestController.java
+++ b/src/main/java/sopt/org/motivooServer/global/healthcheck/SlackTestController.java
@@ -15,7 +15,7 @@ public class SlackTestController {
 
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<ApiResponse> exceptionTest() {
+	public ResponseEntity<ApiResponse<Object>> exceptionTest() {
 		throw new IllegalArgumentException();
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/response/SuccessType.java
+++ b/src/main/java/sopt/org/motivooServer/global/response/SuccessType.java
@@ -20,7 +20,6 @@ public enum SuccessType {
 	//미션
 	GET_MISSION_IMAGE_PRE_SIGNED_URL_SUCCESS(HttpStatus.OK, "미션 인증사진의 Presigned Url을 생성하는 데 성공했습니다."),
 	GET_MISSION_HISTORY_SUCCESS(HttpStatus.OK, "이전 운동 미션 히스토리를 조회하는 데 성공했습니다."),
-	GET_TODAY_MISSION_SUCCESS(HttpStatus.OK, "오늘의 미션을 조회하는 데 성공했습니다."),
 
 	//유저
 	GET_MYINFO_SUCCESS(HttpStatus.OK, "마이페이지 나의 정보 조회에 성공했습니다."),
@@ -43,6 +42,7 @@ public enum SuccessType {
 	 * 201 Created
 	 */
 	CHOICE_TODAY_MISSION_SUCCESS(HttpStatus.CREATED, "오늘의 미션 선정에 성공했습니다."),
+	GET_TODAY_MISSION_SUCCESS(HttpStatus.CREATED, "오늘의 미션을 조회하는 데 성공했습니다."),
 
 
 	;

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -83,6 +83,31 @@
         }
       }
     },
+    "/mission" : {
+      "get" : {
+        "tags" : [ "유저미션" ],
+        "summary" : "지난 30일 간의 운동 인증을 모아보는 API",
+        "description" : "지난 30일 간의 운동 인증을 모아보는 API",
+        "operationId" : "운동 모아보기 API 성공 Example",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/mission1210499860"
+                },
+                "examples" : {
+                  "운동 모아보기 API 성공 Example" : {
+                    "value" : "{\n  \"code\" : 200,\n  \"message\" : \"이전 운동 미션 히스토리를 조회하는 데 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"user_type\" : \"자녀\",\n    \"today_mission\" : {\n      \"mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\"\n    },\n    \"mission_history\" : [ {\n      \"my_mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\",\n      \"my_mission_img_url\" : \"s3 img url\",\n      \"my_mission_status\" : \"없음\",\n      \"opponent_mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\",\n      \"opponent_mission_img_url\" : \"s3 img url\",\n      \"opponent_mission_status\" : \"없음\",\n      \"date\" : \"2024년 1월 15일 월요일\"\n    }, {\n      \"my_mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\",\n      \"my_mission_img_url\" : \"s3 img url\",\n      \"my_mission_status\" : \"없음\",\n      \"opponent_mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\",\n      \"opponent_mission_img_url\" : \"s3 img url\",\n      \"opponent_mission_status\" : \"없음\",\n      \"date\" : \"2024년 1월 15일 월요일\"\n    } ]\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/mission/image" : {
       "patch" : {
         "tags" : [ "유저미션" ],
@@ -114,6 +139,70 @@
                 "examples" : {
                   "미션 인증 사진 등록 API 성공 Example" : {
                     "value" : "{\n  \"code\" : 200,\n  \"message\" : \"미션 인증사진의 Presigned Url을 생성하는 데 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"img_presigned_url\" : \"https://motivoo-server-bucket.s3.ap-northeast-2.amazonaws.com/mission/39e545f4-9ad8-4c05-a8cb-960d0787e776.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T051832Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIASRIQXMUZKAKLJQGJ%2F20240109%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=0c98a5efeaea9bbf607becaaeb511495b68e83b9897b193ef542fa4a8c352dd4\",\n    \"file_name\" : \"39e545f4-9ad8-4c05-a8cb-960d0787e776.jpg\"\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mission/today" : {
+      "post" : {
+        "tags" : [ "유저미션" ],
+        "summary" : "2가지 운동 미션 중 오늘의 미션을 선택하는 API",
+        "description" : "2가지 운동 미션 중 오늘의 미션을 선택하는 API",
+        "operationId" : "오늘의 미션 선정 API 성공 Example",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/mission-today-43304617"
+              },
+              "examples" : {
+                "오늘의 미션 선정 API 성공 Example" : {
+                  "value" : "{\n  \"mission_id\" : 5\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "201",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/mission-today-912747800"
+                },
+                "examples" : {
+                  "오늘의 미션 선정 API 성공 Example" : {
+                    "value" : "{\n  \"code\" : 201,\n  \"message\" : \"오늘의 미션 선정에 성공했습니다.\",\n  \"success\" : true\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mission/today/choice" : {
+      "post" : {
+        "tags" : [ "유저미션" ],
+        "summary" : "2가지 미션 선택지 또는 그 중 선정한 오늘의 미션을 조회하는 API",
+        "description" : "2가지 미션 선택지 또는 그 중 선정한 오늘의 미션을 조회하는 API",
+        "operationId" : "오늘의 미션 조회 API 성공 Example #1",
+        "responses" : {
+          "201" : {
+            "description" : "201",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/mission-today-choice-1727247986"
+                },
+                "examples" : {
+                  "오늘의 미션 조회 API 성공 Example #1" : {
+                    "value" : "{\n  \"code\" : 201,\n  \"message\" : \"오늘의 미션을 조회하는 데 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"is_choice_finished\" : true,\n    \"mission_choice_list\" : null,\n    \"today_mission\" : {\n      \"mission_content\" : \"10000걸음 걷고 벽스쿼트 45초 하기\",\n      \"mission_description\" : \"Notion 링크\",\n      \"mission_step_count\" : 10000,\n      \"mission_quest\" : \"손가락 하트 만들어서 찍기 \"\n    }\n  }\n}"
                   }
                 }
               }
@@ -175,6 +264,23 @@
   },
   "components" : {
     "schemas" : {
+      "mission-today-912747800" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "number",
+            "description" : "상태 코드"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "상태 메세지"
+          }
+        }
+      },
       "api-health279159985" : {
         "type" : "object",
         "properties" : {
@@ -202,6 +308,129 @@
           "img_prefix" : {
             "type" : "string",
             "description" : "운동 인증 사진 디렉터리"
+          }
+        }
+      },
+      "mission1210499860" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "number",
+            "description" : "상태 코드"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "user_type" : {
+                "type" : "string",
+                "description" : "유저의 타입(PARENT|CHILD)"
+              },
+              "mission_history" : {
+                "type" : "array",
+                "description" : "미션 히스토리",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "date" : {
+                      "type" : "string",
+                      "description" : "미션 일자"
+                    },
+                    "opponent_mission_content" : {
+                      "type" : "string",
+                      "description" : "상대측의 미션 내용"
+                    },
+                    "my_mission_img_url" : {
+                      "type" : "string",
+                      "description" : "나의 미션 인증 이미지 url "
+                    },
+                    "opponent_mission_status" : {
+                      "type" : "string",
+                      "description" : "상대측의 미션 달성 상태 (진행중 | 성공 | 실패)"
+                    },
+                    "my_mission_status" : {
+                      "type" : "string",
+                      "description" : "나의 미션 달성 상태 (진행중 | 성공 | 실패)"
+                    },
+                    "my_mission_content" : {
+                      "type" : "string",
+                      "description" : "나의 미션 내용"
+                    },
+                    "opponent_mission_img_url" : {
+                      "type" : "string",
+                      "description" : "상대측의 미션 인증 이미지 url"
+                    }
+                  }
+                }
+              },
+              "today_mission" : {
+                "type" : "object",
+                "properties" : {
+                  "mission_content" : {
+                    "type" : "string",
+                    "description" : "오늘의 미션 내용"
+                  }
+                },
+                "description" : "오늘의 미션"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "상태 메세지"
+          }
+        }
+      },
+      "mission-today-choice-1727247986" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "number",
+            "description" : "상태 코드"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "is_choice_finished" : {
+                "type" : "boolean",
+                "description" : "미션 선정 여부 → false"
+              },
+              "today_mission" : {
+                "type" : "object",
+                "properties" : {
+                  "mission_quest" : {
+                    "type" : "string",
+                    "description" : "흥미유발을 위한 랜덤 미션 퀘스트\n*사진 포즈"
+                  },
+                  "mission_description" : {
+                    "type" : "string",
+                    "description" : "운동 방법 설명 링크"
+                  },
+                  "mission_content" : {
+                    "type" : "string",
+                    "description" : "오늘의 미션 내용"
+                  },
+                  "mission_step_count" : {
+                    "type" : "number",
+                    "description" : "오늘의 미션 걸음 수"
+                  }
+                },
+                "description" : "오늘의 미션"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "상태 메세지"
           }
         }
       },
@@ -334,6 +563,15 @@
           "message" : {
             "type" : "string",
             "description" : "상태 메세지"
+          }
+        }
+      },
+      "mission-today-43304617" : {
+        "type" : "object",
+        "properties" : {
+          "mission_id" : {
+            "type" : "number",
+            "description" : "선택한 미션 번호"
           }
         }
       },

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -10,6 +10,13 @@
   }, {
     "url" : "http://localhost:8080"
   } ],
+  "security": [
+    {
+      "jwtAuth": [
+
+      ]
+    }
+  ],
   "tags" : [ ],
   "paths" : {
     "/api/health" : {
@@ -37,26 +44,56 @@
         }
       }
     },
-    "/mission/image/{missionId}" : {
+    "/home" : {
+      "patch" : {
+        "tags" : [ "유저미션" ],
+        "summary" : "홈 화면 조회 시 걸음 수 요청값에 대한 미션 상태 업데이트 결과 및 부모-자녀 유저의 목표 걸음 수 반환",
+        "description" : "홈 화면 조회 시 걸음 수 요청값에 대한 미션 상태 업데이트 결과 및 부모-자녀 유저의 목표 걸음 수 반환",
+        "operationId" : "홈 화면 미션 달성 상태 조회 API 성공 Example",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/home1356191784"
+              },
+              "examples" : {
+                "홈 화면 미션 달성 상태 조회 API 성공 Example" : {
+                  "value" : "{\n  \"my_step_count\" : 14000,\n  \"opponent_step_count\" : 3000\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/home1096022346"
+                },
+                "examples" : {
+                  "홈 화면 미션 달성 상태 조회 API 성공 Example" : {
+                    "value" : "{\n  \"code\" : 200,\n  \"message\" : \"미션 인증사진의 Presigned Url을 생성하는 데 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"user_type\" : \"CHILD\",\n    \"user_id\" : 2,\n    \"user_goal_step_count\" : 10000,\n    \"opponent_user_id\" : 3,\n    \"opponent_user_goal_step_count\" : 20000,\n    \"is_step_count_completed\" : false\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mission/image" : {
       "patch" : {
         "tags" : [ "유저미션" ],
         "summary" : "미션 인증 사진 업로드를 위한 PreSigned Url 반환",
         "description" : "미션 인증 사진 업로드를 위한 PreSigned Url 반환",
         "operationId" : "미션 인증 사진 등록 API 성공 Example",
-        "parameters" : [ {
-          "name" : "missionId",
-          "in" : "path",
-          "description" : "",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
         "requestBody" : {
           "content" : {
             "application/json;charset=UTF-8" : {
               "schema" : {
-                "$ref" : "#/components/schemas/mission-image-missionId-891843899"
+                "$ref" : "#/components/schemas/mission-image-891843899"
               },
               "examples" : {
                 "미션 인증 사진 등록 API 성공 Example" : {
@@ -72,11 +109,36 @@
             "content" : {
               "application/json;charset=UTF-8" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/mission-image-missionId1808541440"
+                  "$ref" : "#/components/schemas/mission-image1808541440"
                 },
                 "examples" : {
                   "미션 인증 사진 등록 API 성공 Example" : {
                     "value" : "{\n  \"code\" : 200,\n  \"message\" : \"미션 인증사진의 Presigned Url을 생성하는 데 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"img_presigned_url\" : \"https://motivoo-server-bucket.s3.ap-northeast-2.amazonaws.com/mission/39e545f4-9ad8-4c05-a8cb-960d0787e776.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T051832Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIASRIQXMUZKAKLJQGJ%2F20240109%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=0c98a5efeaea9bbf607becaaeb511495b68e83b9897b193ef542fa4a8c352dd4\",\n    \"file_name\" : \"39e545f4-9ad8-4c05-a8cb-960d0787e776.jpg\"\n  }\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/exercise" : {
+      "get" : {
+        "tags" : [ "유저" ],
+        "summary" : "마이페이지 운동정보 조회",
+        "description" : "마이페이지 운동정보 조회",
+        "operationId" : "마이페이지 운동정보 조회 API 성공 Example",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/user-exercise-223104208"
+                },
+                "examples" : {
+                  "마이페이지 운동정보 조회 API 성공 Example" : {
+                    "value" : "{\n  \"code\" : 200,\n  \"message\" : \"마이페이지 건강 정보 조회에 성공했습니다.\",\n  \"success\" : true,\n  \"data\" : {\n    \"is_exercise\" : true,\n    \"exercise_type\" : \"고강도\",\n    \"exercise_frequency\" : \"3일\",\n    \"exercise_time\" : \"2~3시간\",\n    \"health_notes\" : [ \"목\", \"어깨\" ]\n  }\n}"
                   }
                 }
               }
@@ -134,7 +196,7 @@
           }
         }
       },
-      "mission-image-missionId-891843899" : {
+      "mission-image-891843899" : {
         "type" : "object",
         "properties" : {
           "img_prefix" : {
@@ -143,7 +205,108 @@
           }
         }
       },
-      "mission-image-missionId1808541440" : {
+      "user-exercise-223104208" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "number",
+            "description" : "상태 코드"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "health_notes" : {
+                "type" : "array",
+                "description" : "건강 주의사항",
+                "items" : {
+                  "oneOf" : [ {
+                    "type" : "object"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string"
+                  }, {
+                    "type" : "number"
+                  } ]
+                }
+              },
+              "exercise_frequency" : {
+                "type" : "string",
+                "description" : "주 평균 운동 횟수"
+              },
+              "exercise_time" : {
+                "type" : "string",
+                "description" : "하루 평균 운동 시간"
+              },
+              "is_exercise" : {
+                "type" : "boolean",
+                "description" : "운동 여부"
+              },
+              "exercise_type" : {
+                "type" : "string",
+                "description" : "운동 유형"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "상태 메세지"
+          }
+        }
+      },
+      "home1096022346" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "number",
+            "description" : "상태 코드"
+          },
+          "data" : {
+            "type" : "object",
+            "properties" : {
+              "opponent_user_goal_step_count" : {
+                "type" : "number",
+                "description" : "상대 유저 오늘의 미션 목표 걸음 수"
+              },
+              "user_type" : {
+                "type" : "string",
+                "description" : "유저의 타입(PARENT|CHILD)"
+              },
+              "user_goal_step_count" : {
+                "type" : "number",
+                "description" : "유저 오늘의 미션 목표 걸음 수 "
+              },
+              "user_id" : {
+                "type" : "number",
+                "description" : "유저 자신의 아이디"
+              },
+              "is_step_count_completed" : {
+                "type" : "boolean",
+                "description" : "걸음 수 달성 여부 → 운동 인증하기 버튼 활성화"
+              },
+              "opponent_user_id" : {
+                "type" : "number",
+                "description" : "매칭된 상대 유저의 아이디"
+              }
+            },
+            "description" : "응답 데이터"
+          },
+          "success" : {
+            "type" : "boolean",
+            "description" : "응답 성공 여부"
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "상태 메세지"
+          }
+        }
+      },
+      "mission-image1808541440" : {
         "type" : "object",
         "properties" : {
           "code" : {
@@ -171,6 +334,19 @@
           "message" : {
             "type" : "string",
             "description" : "상태 메세지"
+          }
+        }
+      },
+      "home1356191784" : {
+        "type" : "object",
+        "properties" : {
+          "opponent_step_count" : {
+            "type" : "number",
+            "description" : "상대 측(부모/자녀)의 걸음 수"
+          },
+          "my_step_count" : {
+            "type" : "number",
+            "description" : "자신의 걸음 수"
           }
         }
       },
@@ -208,6 +384,13 @@
             "description" : "상태 메세지"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "jwtAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/src/test/java/sopt/org/motivooServer/controller/HealthCheckControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/HealthCheckControllerTest.java
@@ -1,8 +1,8 @@
 package sopt.org.motivooServer.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static sopt.org.motivooServer.global.response.SuccessType.*;
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -23,7 +22,6 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.global.healthcheck.HealthCheckController;
 import sopt.org.motivooServer.global.response.ApiResponse;
-import sopt.org.motivooServer.util.ApiDocumentUtil;
 
 @Slf4j
 @DisplayName("HealthCheckController 테스트")
@@ -49,7 +47,7 @@ public class HealthCheckControllerTest extends BaseControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.accept(MediaType.APPLICATION_JSON)
 		).andDo(
-			MockMvcRestDocumentation.document("healthCheck",
+			document("healthCheck",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				resource(

--- a/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
@@ -1,5 +1,6 @@
 package sopt.org.motivooServer.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -16,7 +17,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -68,7 +68,7 @@ public class HomeControllerTest extends BaseControllerTest{
 			.content(objectMapper.writeValueAsString(request))
 			.principal(principal)
 		).andDo(
-			MockMvcRestDocumentation.document("홈 화면 미션 달성 상태 조회 API 성공 Example",
+			document("홈 화면 미션 달성 상태 조회 API 성공 Example",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				resource(

--- a/src/test/java/sopt/org/motivooServer/controller/UserControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserControllerTest.java
@@ -1,11 +1,9 @@
 package sopt.org.motivooServer.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -14,7 +12,6 @@ import static sopt.org.motivooServer.util.ApiDocumentUtil.*;
 
 import java.security.Principal;
 import java.util.Arrays;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,20 +19,16 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 
 import lombok.extern.slf4j.Slf4j;
-import sopt.org.motivooServer.domain.auth.config.UserAuthentication;
 import sopt.org.motivooServer.domain.user.controller.UserController;
 import sopt.org.motivooServer.domain.user.dto.response.MyHealthInfoResponse;
 import sopt.org.motivooServer.domain.user.dto.response.MyPageInfoResponse;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.response.ApiResponse;
-import sopt.org.motivooServer.util.ApiDocumentUtil;
 
 @Slf4j
 @WithMockUser(roles = "USER")

--- a/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
@@ -27,6 +27,7 @@ import sopt.org.motivooServer.domain.mission.controller.UserMissionController;
 import sopt.org.motivooServer.domain.mission.dto.request.MissionImgUrlRequest;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
+import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
 import sopt.org.motivooServer.fixture.MissionFixture;
 import sopt.org.motivooServer.fixture.UserMissionFixture;
 import sopt.org.motivooServer.global.response.ApiResponse;
@@ -139,6 +140,84 @@ public class UserMissionControllerTest extends BaseControllerTest{
 						.build()
 				)
 			)).andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
+	@DisplayName("오늘의 미션 조회 API 테스트")
+	void getTodayMission() throws Exception {
+
+		// given
+		TodayMissionResponse response = UserMissionFixture.createTodayMissionResponse();
+
+		ResponseEntity<ApiResponse<TodayMissionResponse>> result = ApiResponse.success(
+			GET_TODAY_MISSION_SUCCESS, response);
+
+		// when
+		when(userMissionController.getTodayMission(principal)).thenReturn(result);
+
+		// then
+		mockMvc.perform(post(DEFAULT_URL + "/today/choice")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.principal(principal)
+		).andDo(
+			document("오늘의 미션 조회 API 성공 Example #1",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				resource(
+					ResourceSnippetParameters.builder()
+						.tag(TAG)
+						.description("2가지 미션 선택지 또는 그 중 선정한 오늘의 미션을 조회하는 API")
+						.requestFields(
+							// fieldWithPath("mission_id").type(NUMBER).description("선택한 미션 번호")
+						)
+						.responseFields(
+							fieldWithPath("code").type(NUMBER).description("상태 코드"),
+							fieldWithPath("message").type(STRING).description("상태 메세지"),
+							fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"),
+							fieldWithPath("data").description("응답 데이터"),
+							fieldWithPath("data.is_choice_finished").type(BOOLEAN).description("미션 선정 여부 → false"),
+							fieldWithPath("data.mission_choice_list").type(NULL).description("오늘의 미션 선택지 리스트"),
+							// fieldWithPath("data.mission_choice_list[]").type(OBJECT).description(""),
+							// fieldWithPath("data.mission_choice_list[].mission_id").type(NUMBER).description("미션 번호"),
+							// fieldWithPath("data.mission_choice_list[].mission_content").type(STRING).description("미션 내용"),
+							fieldWithPath("data.today_mission").type(OBJECT).description("오늘의 미션"),
+							fieldWithPath("data.today_mission.mission_content").type(STRING).description("오늘의 미션 내용"),
+							fieldWithPath("data.today_mission.mission_description").type(STRING).description("운동 방법 설명 링크"),
+							fieldWithPath("data.today_mission.mission_step_count").type(NUMBER).description("오늘의 미션 걸음 수"),
+							fieldWithPath("data.today_mission.mission_quest").type(STRING).description("흥미유발을 위한 랜덤 미션 퀘스트\n*사진 포즈"))
+
+						.build()
+				)
+			))
+			// document("오늘의 미션 조회 API 성공 Example #2",
+			// 	getDocumentRequest(),
+			// 	getDocumentResponse(),
+			// 	resource(
+			// 		ResourceSnippetParameters.builder()
+			// 			.tag(TAG)
+			// 			.description("2가지 미션 선택지 또는 그 중 선정한 오늘의 미션을 조회하는 API")
+			// 			.requestFields(
+			// 				fieldWithPath("mission_id").type(NUMBER).description("선택한 미션 번호")
+			// 			)
+			// 			.responseFields(
+			// 				fieldWithPath("code").type(NUMBER).description("상태 코드"),
+			// 				fieldWithPath("message").type(STRING).description("상태 메세지"),
+			// 				fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"),
+			// 				fieldWithPath("data").description("응답 데이터"),
+			// 				fieldWithPath("data.is_choice_finished").type(BOOLEAN).description("미션 선정 여부 → false"),
+			// 				fieldWithPath("data.mission_choice_list").type(ARRAY).description("오늘의 미션 선택지 리스트"),
+			// 				fieldWithPath("data.mission_choice_list[].mission_id").type(NUMBER).description("미션 번호"),
+			// 				fieldWithPath("data.mission_choice_list[].mission_content").type(STRING).description("미션 내용"),
+			// 				fieldWithPath("data.today_mission").type(OBJECT).description("오늘의 미션"),
+			// 				fieldWithPath("data.today_mission.mission_content").type(STRING).description("오늘의 미션 내용"),
+			// 				fieldWithPath("data.today_mission.mission_description").type(STRING).description("운동 방법 설명 링크"),
+			// 				fieldWithPath("data.today_mission.mission_quest").type(STRING).description("흥미유발을 위한 랜덤 미션 퀘스트\n*사진 포즈"))
+			//
+			// 			.build()
+			// 	))
+
+			.andExpect(MockMvcResultMatchers.status().isOk());
 	}
 
 

--- a/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
@@ -217,7 +217,7 @@ public class UserMissionControllerTest extends BaseControllerTest{
 			// 			.build()
 			// 	))
 
-			.andExpect(MockMvcResultMatchers.status().isOk());
+			.andExpect(MockMvcResultMatchers.status().isCreated());
 	}
 
 

--- a/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
@@ -25,6 +25,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.mission.controller.UserMissionController;
 import sopt.org.motivooServer.domain.mission.dto.request.MissionImgUrlRequest;
+import sopt.org.motivooServer.domain.mission.dto.request.TodayMissionChoiceRequest;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
@@ -168,9 +169,7 @@ public class UserMissionControllerTest extends BaseControllerTest{
 					ResourceSnippetParameters.builder()
 						.tag(TAG)
 						.description("2가지 미션 선택지 또는 그 중 선정한 오늘의 미션을 조회하는 API")
-						.requestFields(
-							// fieldWithPath("mission_id").type(NUMBER).description("선택한 미션 번호")
-						)
+						.requestFields()
 						.responseFields(
 							fieldWithPath("code").type(NUMBER).description("상태 코드"),
 							fieldWithPath("message").type(STRING).description("상태 메세지"),
@@ -218,6 +217,46 @@ public class UserMissionControllerTest extends BaseControllerTest{
 			// 	))
 
 			.andExpect(MockMvcResultMatchers.status().isCreated());
+	}
+
+	@Test
+	@DisplayName("오늘의 미션 선정 API 테스트")
+	void choiceTodayMission() throws Exception {
+
+		// given
+		TodayMissionChoiceRequest request = new TodayMissionChoiceRequest(5L);
+		ResponseEntity<ApiResponse<Object>> result = ApiResponse.success(
+			CHOICE_TODAY_MISSION_SUCCESS);
+
+		// when
+		when(userMissionController.choiceTodayMission(request, principal)).thenReturn(result);
+
+		// then
+		mockMvc.perform(post(DEFAULT_URL + "/today")
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request))
+			.principal(principal)
+		).andDo(
+			document("오늘의 미션 선정 API 성공 Example",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				resource(
+					ResourceSnippetParameters.builder()
+						.tag(TAG)
+						.description("2가지 운동 미션 중 오늘의 미션을 선택하는 API")
+						.requestFields(
+							fieldWithPath("mission_id").type(NUMBER).description("선택한 미션 번호")
+						)
+						.responseFields(
+							fieldWithPath("code").type(NUMBER).description("상태 코드"),
+							fieldWithPath("message").type(STRING).description("상태 메세지"),
+							fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"))
+							// fieldWithPath("data").type(NULL).description("응답 데이터"))
+
+						.build()
+				)
+			)).andExpect(MockMvcResultMatchers.status().isCreated());
 	}
 
 

--- a/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
@@ -29,7 +29,6 @@ import sopt.org.motivooServer.domain.mission.dto.request.TodayMissionChoiceReque
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
-import sopt.org.motivooServer.fixture.MissionFixture;
 import sopt.org.motivooServer.fixture.UserMissionFixture;
 import sopt.org.motivooServer.global.response.ApiResponse;
 
@@ -40,7 +39,6 @@ public class UserMissionControllerTest extends BaseControllerTest{
 
 	private static final String DEFAULT_URL = "/mission";
 	private static final String TAG = "유저미션";
-	private static final String MISSION_ICON_URL = "https://motivoo-server-bucket.s3.ap-northeast-2.amazonaws.com/icon/icon_mission_rest.png";
 
 	@MockBean
 	private UserMissionController userMissionController;

--- a/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/UserMissionControllerTest.java
@@ -1,12 +1,13 @@
 package sopt.org.motivooServer.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static sopt.org.motivooServer.global.response.SuccessType.*;
 import static sopt.org.motivooServer.global.external.s3.S3BucketDirectory.*;
+import static sopt.org.motivooServer.global.response.SuccessType.*;
 import static sopt.org.motivooServer.util.ApiDocumentUtil.*;
 
 import java.security.Principal;
@@ -17,7 +18,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -25,7 +25,10 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.mission.controller.UserMissionController;
 import sopt.org.motivooServer.domain.mission.dto.request.MissionImgUrlRequest;
+import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
+import sopt.org.motivooServer.fixture.MissionFixture;
+import sopt.org.motivooServer.fixture.UserMissionFixture;
 import sopt.org.motivooServer.global.response.ApiResponse;
 
 @Slf4j
@@ -35,6 +38,7 @@ public class UserMissionControllerTest extends BaseControllerTest{
 
 	private static final String DEFAULT_URL = "/mission";
 	private static final String TAG = "유저미션";
+	private static final String MISSION_ICON_URL = "https://motivoo-server-bucket.s3.ap-northeast-2.amazonaws.com/icon/icon_mission_rest.png";
 
 	@MockBean
 	private UserMissionController userMissionController;
@@ -47,7 +51,6 @@ public class UserMissionControllerTest extends BaseControllerTest{
 	void getMissionImgPresignedUrl() throws Exception {
 
 		// given
-		Long missionId = 1L;
 		MissionImgUrlRequest request = new MissionImgUrlRequest(MISSION_PREFIX.value());
 		MissionImgUrlResponse response = MissionImgUrlResponse.of(
 			"https://motivoo-server-bucket.s3.ap-northeast-2.amazonaws.com/mission/39e545f4-9ad8-4c05-a8cb-960d0787e776.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240109T051832Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIASRIQXMUZKAKLJQGJ%2F20240109%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=0c98a5efeaea9bbf607becaaeb511495b68e83b9897b193ef542fa4a8c352dd4",
@@ -66,7 +69,7 @@ public class UserMissionControllerTest extends BaseControllerTest{
 			.content(objectMapper.writeValueAsString(request))
 			.principal(principal)
 		).andDo(
-			MockMvcRestDocumentation.document("미션 인증 사진 등록 API 성공 Example",
+			document("미션 인증 사진 등록 API 성공 Example",
 				getDocumentRequest(),
 				getDocumentResponse(),
 				resource(
@@ -83,6 +86,56 @@ public class UserMissionControllerTest extends BaseControllerTest{
 							fieldWithPath("data").description("응답 데이터"),
 							fieldWithPath("data.img_presigned_url").type(STRING).description("S3 PreSigned Url"),
 							fieldWithPath("data.file_name").type(STRING).description("이미지 파일명(UUID로 임의 지정)"))
+						.build()
+				)
+			)).andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
+	@DisplayName("운동 모아보기 API 테스트")
+	void getMissionHistory() throws Exception {
+
+		// given
+		MissionHistoryResponse response = UserMissionFixture.createMissionHistoryResponse();
+
+		ResponseEntity<ApiResponse<MissionHistoryResponse>> result = ApiResponse.success(
+			GET_MISSION_HISTORY_SUCCESS, response);
+
+		// when
+		when(userMissionController.getUserMissionHistory(principal)).thenReturn(result);
+
+		// then
+		mockMvc.perform(get(DEFAULT_URL)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.APPLICATION_JSON)
+			.principal(principal)
+		).andDo(
+			document("운동 모아보기 API 성공 Example",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				resource(
+					ResourceSnippetParameters.builder()
+						.tag(TAG)
+						.description("지난 30일 간의 운동 인증을 모아보는 API")
+						.requestFields()
+						.responseFields(
+							fieldWithPath("code").type(NUMBER).description("상태 코드"),
+							fieldWithPath("message").type(STRING).description("상태 메세지"),
+							fieldWithPath("success").type(BOOLEAN).description("응답 성공 여부"),
+							fieldWithPath("data").description("응답 데이터"),
+							fieldWithPath("data.user_type").type(STRING).description("유저의 타입(PARENT|CHILD)"),
+							fieldWithPath("data.today_mission").type(OBJECT).description("오늘의 미션"),
+							fieldWithPath("data.today_mission.mission_content").type(STRING).description("오늘의 미션 내용"),
+							fieldWithPath("data.mission_history").type(ARRAY).description("미션 히스토리"),
+							fieldWithPath("data.mission_history[].date").type(STRING).description("미션 일자"),
+							fieldWithPath("data.mission_history[].my_mission_content").type(STRING).description("나의 미션 내용"),
+							fieldWithPath("data.mission_history[].my_mission_img_url").type(STRING).description("나의 미션 인증 이미지 url "),
+							fieldWithPath("data.mission_history[].my_mission_status").type(STRING).description("나의 미션 달성 상태 (진행중 | 성공 | 실패)"),
+							fieldWithPath("data.mission_history[].opponent_mission_content").type(STRING).description("상대측의 미션 내용"),
+							fieldWithPath("data.mission_history[].opponent_mission_img_url").type(STRING).description("상대측의 미션 인증 이미지 url"),
+							fieldWithPath("data.mission_history[].opponent_mission_status").type(STRING).description("상대측의 미션 달성 상태 (진행중 | 성공 | 실패)"))
+
+
 						.build()
 				)
 			)).andExpect(MockMvcResultMatchers.status().isOk());

--- a/src/test/java/sopt/org/motivooServer/fixture/MissionFixture.java
+++ b/src/test/java/sopt/org/motivooServer/fixture/MissionFixture.java
@@ -1,0 +1,49 @@
+package sopt.org.motivooServer.fixture;
+
+import lombok.val;
+import sopt.org.motivooServer.domain.mission.entity.Mission;
+import sopt.org.motivooServer.domain.user.entity.UserType;
+
+public class MissionFixture {
+
+	private static final String MISSION_CONTENT = "10000걸음 걷고 벽스쿼트 45초 하기";
+	private static final int MISSION_STEP_COUNT = 10000;
+	private static final String MISSION_BODY_PART = "하체";
+	private static final String MISSION_ICON_URL = "https://gayeong04.notion.site/20a76151a5804d44b00086c60f0376c2?pvs=4";
+	private static final String MISSION_HEALTH_NOTES = "무릎";
+	private static final UserType MISSION_TARGET = UserType.CHILD;
+	private static final String MISSION_TYPE = "고수";
+
+	private static final String MISSION_CONTENT2 = "10000걸음 걷고 벽스쿼트 45초 하기";
+	private static final int MISSION_STEP_COUNT2 = 10000;
+	private static final String MISSION_BODY_PART2 = "하체";
+	private static final String MISSION_ICON_URL2 = "https://gayeong04.notion.site/20a76151a5804d44b00086c60f0376c2?pvs=4";
+	private static final String MISSION_HEALTH_NOTES2 = "무릎";
+	private static final UserType MISSION_TARGET2 = UserType.CHILD;
+	private static final String MISSION_TYPE2 = "고수";
+
+
+	public static Mission createMission() {
+		val mission = Mission.builder()
+			.bodyPart(MISSION_BODY_PART)
+			.content(MISSION_CONTENT)
+			.stepCount(MISSION_STEP_COUNT)
+			.iconUrl(MISSION_ICON_URL)
+			.healthNotes(MISSION_HEALTH_NOTES)
+			.target(MISSION_TARGET)
+			.type(MISSION_TYPE).build();
+		return mission;
+	}
+
+	public static Mission createMissionV2() {
+		val mission = Mission.builder()
+			.bodyPart(MISSION_BODY_PART2)
+			.content(MISSION_CONTENT2)
+			.stepCount(MISSION_STEP_COUNT2)
+			.iconUrl(MISSION_ICON_URL2)
+			.healthNotes(MISSION_HEALTH_NOTES2)
+			.target(MISSION_TARGET2)
+			.type(MISSION_TYPE2).build();
+		return mission;
+	}
+}

--- a/src/test/java/sopt/org/motivooServer/fixture/MissionFixture.java
+++ b/src/test/java/sopt/org/motivooServer/fixture/MissionFixture.java
@@ -13,6 +13,7 @@ public class MissionFixture {
 	private static final String MISSION_HEALTH_NOTES = "무릎";
 	private static final UserType MISSION_TARGET = UserType.CHILD;
 	private static final String MISSION_TYPE = "고수";
+	private static final String MISSION_DESCRIPTION = "Notion 링크";
 
 	private static final String MISSION_CONTENT2 = "10000걸음 걷고 벽스쿼트 45초 하기";
 	private static final int MISSION_STEP_COUNT2 = 10000;
@@ -21,6 +22,8 @@ public class MissionFixture {
 	private static final String MISSION_HEALTH_NOTES2 = "무릎";
 	private static final UserType MISSION_TARGET2 = UserType.CHILD;
 	private static final String MISSION_TYPE2 = "고수";
+	private static final String MISSION_DESCRIPTION2 = "운동방법 설명 링크";
+
 
 
 	public static Mission createMission() {
@@ -31,7 +34,8 @@ public class MissionFixture {
 			.iconUrl(MISSION_ICON_URL)
 			.healthNotes(MISSION_HEALTH_NOTES)
 			.target(MISSION_TARGET)
-			.type(MISSION_TYPE).build();
+			.type(MISSION_TYPE)
+			.descriptionUrl(MISSION_DESCRIPTION).build();
 		return mission;
 	}
 
@@ -43,7 +47,8 @@ public class MissionFixture {
 			.iconUrl(MISSION_ICON_URL2)
 			.healthNotes(MISSION_HEALTH_NOTES2)
 			.target(MISSION_TARGET2)
-			.type(MISSION_TYPE2).build();
+			.type(MISSION_TYPE2)
+			.descriptionUrl(MISSION_DESCRIPTION2).build();
 		return mission;
 	}
 }

--- a/src/test/java/sopt/org/motivooServer/fixture/UserFixture.java
+++ b/src/test/java/sopt/org/motivooServer/fixture/UserFixture.java
@@ -1,0 +1,48 @@
+package sopt.org.motivooServer.fixture;
+
+import lombok.val;
+import sopt.org.motivooServer.domain.user.entity.SocialPlatform;
+import sopt.org.motivooServer.domain.user.entity.User;
+import sopt.org.motivooServer.domain.user.entity.UserType;
+
+/**
+ * 테스트코드에서 공통으로 사용할 객체 생성 및 상수 선언을 하기 위한 클래스
+ */
+public class UserFixture {
+
+	private static final String USER_NICKNAME = "모티부";
+
+	private static final int USER_AGE = 20;
+	private static final UserType USER_TYPE = UserType.CHILD;
+	private static final String USER_SOCIAL_ID = "1234567social";
+	private static final SocialPlatform USER_SOCIAL_PLATFORM = SocialPlatform.KAKAO;
+
+	private static final String USER_NICKNAME2 = "모티부";
+
+	private static final int USER_AGE2 = 45;
+	private static final UserType USER_TYPE2 = UserType.PARENT;
+	private static final String USER_SOCIAL_ID2 = "1234567social";
+	private static final SocialPlatform USER_SOCIAL_PLATFORM2 = SocialPlatform.KAKAO;
+
+
+	public static User createUser() {
+		// Lombok에서 제공하는 final 선언
+		val user = User.builderInTest()
+			.nickname(USER_NICKNAME)
+			.age(USER_AGE)
+			.socialId(USER_SOCIAL_ID)
+			.socialPlatform(USER_SOCIAL_PLATFORM)
+			.type(USER_TYPE).build();
+		return user;
+	}
+
+	public static User createUserV2() {
+		val user = User.builderInTest()
+			.nickname(USER_NICKNAME2)
+			.age(USER_AGE2)
+			.socialId(USER_SOCIAL_ID2)
+			.socialPlatform(USER_SOCIAL_PLATFORM2)
+			.type(USER_TYPE2).build();
+		return user;
+	}
+}

--- a/src/test/java/sopt/org/motivooServer/fixture/UserMissionFixture.java
+++ b/src/test/java/sopt/org/motivooServer/fixture/UserMissionFixture.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
+import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
 import sopt.org.motivooServer.domain.mission.entity.CompletedStatus;
 import sopt.org.motivooServer.domain.mission.entity.MissionQuest;
 import sopt.org.motivooServer.domain.mission.entity.UserMission;
@@ -71,5 +72,9 @@ public class UserMissionFixture {
 		User parentUser = createUserV2();
 
 		return MissionHistoryResponse.of(childUser, createUserMission(), createUserMissions(), createUserMissions());
+	}
+
+	public static TodayMissionResponse createTodayMissionResponse() {
+		return TodayMissionResponse.of(createUserMission());
 	}
 }

--- a/src/test/java/sopt/org/motivooServer/fixture/UserMissionFixture.java
+++ b/src/test/java/sopt/org/motivooServer/fixture/UserMissionFixture.java
@@ -1,0 +1,75 @@
+package sopt.org.motivooServer.fixture;
+
+import static sopt.org.motivooServer.fixture.UserFixture.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
+import sopt.org.motivooServer.domain.mission.entity.CompletedStatus;
+import sopt.org.motivooServer.domain.mission.entity.MissionQuest;
+import sopt.org.motivooServer.domain.mission.entity.UserMission;
+import sopt.org.motivooServer.domain.mission.entity.UserMissionChoices;
+import sopt.org.motivooServer.domain.user.entity.User;
+
+@RequiredArgsConstructor
+public class UserMissionFixture {
+
+
+	public static UserMission createUserMission() {
+		val userMission = UserMission.builder()
+			.user(createUser())
+			.mission(MissionFixture.createMission())
+			.missionQuest(createMissionQuest())
+			.completedStatus(CompletedStatus.NONE).build();
+		userMission.updateCreatedAt(LocalDateTime.now());
+		userMission.updateImgUrl("s3 img url");
+		return userMission;
+	}
+
+	public static UserMission createUserMissionV2() {
+		val userMission = UserMission.builder()
+			.user(createUser())
+			.mission(MissionFixture.createMissionV2())
+			.missionQuest(createMissionQuest())
+			.completedStatus(CompletedStatus.NONE).build();
+		userMission.updateCreatedAt(LocalDateTime.now());
+		userMission.updateImgUrl("s3 img url");
+		return userMission;
+	}
+
+	public static MissionQuest createMissionQuest() {
+		return MissionQuest.builder()
+			.content("손가락 하트 만들어서 찍기 ").build();
+	}
+
+	public static List<UserMission> createUserMissions() {
+		List<UserMission> userMissions = new ArrayList<>();
+
+		userMissions.add(createUserMission());
+		userMissions.add(createUserMissionV2());
+		return userMissions;
+	}
+
+	public static List<UserMissionChoices> createUserMissionChoices() {
+		List<UserMissionChoices> userMissionChoices = new ArrayList<>();
+
+		userMissionChoices.add(UserMissionChoices.builder()
+			.user(createUser())
+			.mission(MissionFixture.createMission()).build());
+		userMissionChoices.add(UserMissionChoices.builder()
+			.user(createUser())
+			.mission(MissionFixture.createMissionV2()).build());
+		return userMissionChoices;
+	}
+
+	public static MissionHistoryResponse createMissionHistoryResponse() {
+		User childUser = createUser();
+		User parentUser = createUserV2();
+
+		return MissionHistoryResponse.of(childUser, createUserMission(), createUserMissions(), createUserMissions());
+	}
+}


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #44 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 테스트를 위한 User,UserMission,Mission,MissionQuest 엔티티와 응답 DTO의 fixture 생성
- 엔티티에서 빌더패턴에만 열려 있도록 생성자 정의 (테스트에 필요한 레벨까지만)
- 엔티티 업데이트 로직 추가 
   - 운동 모아보기 API 에서 필요한 생성일시 필드로 객체를 생성하기 위해 BaseTimeEntity의 createdAt, updatedAt 필드를 private -> protected로 열어두었습니다.
- DTO의 of()메서드 명세서에서 반영 안 된 사항 반영

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
