### PR TITLE
[REFACTOR] 오늘의 미션 API 로직 개선

### DIFF
--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/ParentchildMissionDto.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/ParentchildMissionDto.java
@@ -1,6 +1,5 @@
 package sopt.org.motivooServer.domain.mission.dto.response;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 

--- a/src/main/java/sopt/org/motivooServer/domain/mission/entity/UserMission.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/entity/UserMission.java
@@ -56,6 +56,13 @@ public class UserMission extends BaseTimeEntity {
 		this.user = user;
 	}
 
+	@Builder(builderMethodName = "builderForEmpty")
+	private UserMission(CompletedStatus completedStatus, Mission mission, User user) {
+		this.completedStatus = completedStatus;
+		this.mission = mission;
+		this.user = user;
+	}
+
 	//== 연관관계 메서드 ==//
 	public void setUser(User user) {
 		this.user = user;

--- a/src/main/java/sopt/org/motivooServer/domain/mission/exception/MissionExceptionType.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/exception/MissionExceptionType.java
@@ -16,6 +16,7 @@ public enum MissionExceptionType implements BusinessExceptionType {
 	INVALID_MISSION_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 미션 타입 Enum 값입니다."),
 	NOT_FILTERED_TODAY_MISSION(HttpStatus.BAD_REQUEST, "아직 오늘의 미션 선택지가 정해지지 않았습니다."),
 	NOT_EXIST_TODAY_MISSION_CHOICE(HttpStatus.BAD_REQUEST, "미션 선택지에 존재하지 않는 미션 ID 값입니다."),
+	ALREADY_CHOICE_TODAY_MISSION(HttpStatus.BAD_REQUEST, "이미 오늘의 미션을 선정했습니다."),
 
 
 	/**

--- a/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionScheduler.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionScheduler.java
@@ -2,14 +2,26 @@ package sopt.org.motivooServer.domain.mission.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PessimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.mission.entity.CompletedStatus;
+import sopt.org.motivooServer.domain.mission.entity.UserMission;
 import sopt.org.motivooServer.domain.mission.repository.UserMissionRepository;
+import sopt.org.motivooServer.domain.user.entity.User;
+import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.external.s3.S3Service;
 
 @Slf4j
@@ -18,20 +30,76 @@ import sopt.org.motivooServer.global.external.s3.S3Service;
 public class UserMissionScheduler {
 
 	private final UserMissionRepository userMissionRepository;
+	private final UserRepository userRepository;
+
 	private final S3Service s3Service;
+	private final PlatformTransactionManager transactionManager;  // 수동 트랜잭션 처리를 위한 주입
 
+	@PersistenceContext
+	private EntityManager em;
+
+	// 1. 미션 달성 상태 반영
 	@Scheduled(cron = "@daily", zone = "Asia/Seoul")
+	// @Scheduled(cron = "* */2 * * * *", zone = "Asia/Seoul")
 	public void setCompletedStatus() {
+		log.info("미션 달성상태 업데이트 스케줄러 진입");
 
-		// 1. 미션 달성 상태 반영
-		userMissionRepository.findUserMissionsByCreatedAt(LocalDate.now().minusDays(1)).stream()
-			.filter(um -> um.getCompletedStatus() != CompletedStatus.SUCCESS)
-			.forEach(um -> um.updateCompletedStatus(CompletedStatus.FAIL));
+		List<UserMission> missionsByCreatedAt = userMissionRepository.findUserMissionsByCreatedAt(
+			LocalDate.now().minusDays(1));
+		log.info("어제의 UserMission 개수: {}개", missionsByCreatedAt.size());
+		for (UserMission userMission : missionsByCreatedAt) {
 
-		// 2. 새로운 미션 선택지
-		userMissionRepository.findAll().stream()
-			.filter(um -> !um.getUser().getUserMissionChoice().isEmpty())
-			.forEach(um -> um.getUser().clearPreUserMissionChoice());
+			TransactionDefinition transactionDefinition = new DefaultTransactionDefinition();
+			TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
+
+			log.info(userMission.getMission().getContent());
+			log.info(userMission.getCompletedStatus().getValue());
+			if (userMission.getCompletedStatus() != CompletedStatus.SUCCESS) {
+				try {
+					log.info("성공이 아니니 실패여라..");
+					userMission.updateCompletedStatus(CompletedStatus.FAIL);
+					UserMission um = em.merge(userMission);
+					log.info("실패 상태로 업데이트 완료: {}", um.getCompletedStatus());
+					transactionManager.commit(transactionStatus);
+				} catch (PessimisticLockingFailureException | PessimisticLockException e) {
+					transactionManager.rollback(transactionStatus);
+				} finally {
+					em.close();
+				}
+			}
+		}
+	}
+
+	// 2. 오늘의 미션 선택지가 구성되었지만, 선정하지 않고 그냥 넘어간 경우
+	// @Scheduled(cron = "* */2 * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "@daily", zone = "Asia/Seoul")
+	public void setClearPreUserMissionChoices() {
+		log.info("미션 선택지 리스트 초기화 스케줄러 진입");
+
+		List<User> users = userRepository.findAll();
+		log.info("모든 User 개수: {}개", users.size());
+		for (User user : users) {
+
+			TransactionDefinition transactionDefinition = new DefaultTransactionDefinition();
+			TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
+
+			log.info("User {}의 임시 오늘의 미션 선택지 개수: {}개", user.getNickname(), user.getUserMissionChoice().size());
+
+			if (!user.getUserMissionChoice().isEmpty()) {
+				try {
+					log.info("오늘의 미션 선택지 리스트 개수: {}개", user.getUserMissionChoice().size());
+					user.clearPreUserMissionChoice();
+					User u = em.merge(user);
+					log.info("Clear 후 오늘의 미션 선택지 리스트 개수: {}개", u.getUserMissionChoice().size());
+					transactionManager.commit(transactionStatus);
+				} catch (PessimisticLockingFailureException | PessimisticLockException e) {
+					transactionManager.rollback(transactionStatus);
+				} finally {
+					em.close();
+				}
+			}
+		}
+
 	}
 
 	// 매일 새벽 4시마다 30일 이전의 사진은 버킷에서 삭제한다
@@ -41,4 +109,6 @@ public class UserMissionScheduler {
 		userMissionRepository.findUserMissionsByCreatedAtBefore(thirtyDaysAgo)
 			.forEach(um -> s3Service.deleteImage(um.getImgUrl()));
 	}
+
+	//TODO UserMissionChoice DB 초기화
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -147,6 +148,13 @@ public class UserMissionService {
 
 		Mission mission = getMissionById(request.missionId());
 
+		UserMission userMission = createTodayUserMission(mission, user);
+		user.clearPreUserMissionChoice();  // 오늘의 미션을 선정했다면, 선택지 리스트는 비워주기
+		return userMission.getId();
+	}
+
+	@NotNull
+	private UserMission createTodayUserMission(Mission mission, User user) {
 		UserMission userMission = UserMission.builder()
 			.mission(mission)
 			.missionQuest(missionQuestRepository.findRandomMissionQuest())
@@ -155,8 +163,7 @@ public class UserMissionService {
 
 		userMissionRepository.save(userMission);
 		user.addUserMission(userMission);
-		user.clearPreUserMissionChoice();  // 오늘의 미션을 선정했다면, 선택지 리스트는 비워주기
-		return userMission.getId();
+		return userMission;
 	}
 
 	private static void validateTodayMissionRequest(Long missionId, User user) {

--- a/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
@@ -6,13 +6,14 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,6 +21,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.common.BaseTimeEntity;
 import sopt.org.motivooServer.domain.mission.entity.UserMission;
@@ -70,10 +75,10 @@ public class User extends BaseTimeEntity {
 	@JoinColumn(name = "parentchild_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Parentchild parentchild;
 
-	@OneToMany(mappedBy = "user")
+	@OneToMany(mappedBy = "user", fetch = FetchType.EAGER)
 	private final List<UserMission> userMissions = new ArrayList<>();
 
-	@OneToMany
+	@OneToMany(fetch = FetchType.EAGER)
 	private final List<UserMissionChoices> userMissionChoice = new ArrayList<>();
 
 	@Builder
@@ -132,6 +137,7 @@ public class User extends BaseTimeEntity {
 	}
 
 	public void setPreUserMissionChoice(List<UserMissionChoices> userMissionChoice) {
+		log.info("임시 UserMission 선택지(매일 자정 초기화 후, 메인 홈 첫 진입 시 업데이트: {}가지", userMissionChoice.size());
 		if (!this.userMissionChoice.isEmpty()) {
 			clearPreUserMissionChoice();
 		}

--- a/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
@@ -1,17 +1,16 @@
 package sopt.org.motivooServer.domain.user.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import sopt.org.motivooServer.domain.parentchild.entity.Parentchild;
-
 import sopt.org.motivooServer.domain.user.entity.User;
-
-import java.util.List;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -45,4 +44,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u where u.id=?1 and u.deleted=false")
     Optional<User> findById(Long id);
+
+    @Query("SELECT u FROM User u WHERE u.id IN :ids")
+    List<User> findAllByIds(@Param("ids") List<Long> ids);
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #55 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- 홈 뷰에 관한 API 분기처리에 대해 전면 리팩토링을 진행했습니다
- 스케줄링 로직을 분리하고 테스트로 정상 동작을 확인했습니다
- 운동 히스토리에서 오늘의 미션을 선정하지 않은 상대유저를 위해 NONE으로 필드를 채운 EMPTY_USER_MISSION을 생성하도록 했습니다

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
