### PR TITLE
[FEAT] 파이어베이스 실시간 DB 연동을 통한 걸음 수 조회 및 쓰기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ application.yml
 application-test.yml
 
 firebase-ignore.json
+motivoo-firebase-adminsdk.json
 
 **.adoc
 **.http

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 
 ## 🔧 시스템 아키텍처
-<img src="https://github.com/Team-Motivoo/Motivoo-Server/assets/80024278/df301bbd-1d3e-49aa-bc9d-c4ebdec046cd" />
+<img src="https://github.com/Team-Motivoo/Motivoo-Server/assets/80024278/c557f8ff-1d10-4b9c-82fa-057f85c52caf" />
 <br/><br/>
 
 ## ☁️ ERD

--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,9 @@ dependencies {
 	// Feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.7'
 
+	// Firebase
+	implementation "com.google.firebase:firebase-admin:9.1.1"
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/controller/HomeController.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/controller/HomeController.java
@@ -7,12 +7,10 @@ import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import sopt.org.motivooServer.domain.mission.dto.request.MissionStepStatusRequest;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionStepStatusResponse;
 import sopt.org.motivooServer.domain.mission.service.UserMissionService;
 import sopt.org.motivooServer.global.response.ApiResponse;
@@ -25,8 +23,8 @@ public class HomeController {
 	private final UserMissionService userMissionService;
 
 	@PatchMapping
-	public ResponseEntity<ApiResponse<MissionStepStatusResponse>> getMissionCompleted(@RequestBody final MissionStepStatusRequest request, final Principal principal) {
+	public ResponseEntity<ApiResponse<MissionStepStatusResponse>> getMissionCompleted(final Principal principal) {
 		return ApiResponse.success(MISSION_STEP_COUNT_STATUS_SUCCESS,
-			userMissionService.getMissionCompleted(request, getUserFromPrincipal(principal)));
+			userMissionService.getMissionCompleted(getUserFromPrincipal(principal)));
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/request/MissionStepStatusRequest.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/request/MissionStepStatusRequest.java
@@ -1,9 +1,0 @@
-package sopt.org.motivooServer.domain.mission.dto.request;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public record MissionStepStatusRequest(
-	@JsonProperty("my_step_count") Integer myStepCount,
-	@JsonProperty("opponent_step_count") Integer opponentStepCount
-) {
-}

--- a/src/main/java/sopt/org/motivooServer/domain/mission/entity/MissionType.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/entity/MissionType.java
@@ -19,7 +19,8 @@ public enum MissionType {
 	BEGINNER("초보"),
 	BEGIN_INTER("초보&중수"),
 	INTER_ADVANCE("중수&고수"),
-	ALL("초보&중수&고수")
+	ALL("초보&중수&고수"),
+	NONE("없음")
 
 	;
 

--- a/src/main/java/sopt/org/motivooServer/domain/parentchild/service/ParentchildService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/parentchild/service/ParentchildService.java
@@ -31,7 +31,7 @@ import sopt.org.motivooServer.domain.user.entity.User;
 import sopt.org.motivooServer.domain.user.entity.UserType;
 import sopt.org.motivooServer.domain.user.exception.UserException;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
-
+import sopt.org.motivooServer.global.external.firebase.FirebaseService;
 
 import static sopt.org.motivooServer.domain.user.exception.UserExceptionType.INVALID_USER_TYPE;
 
@@ -44,6 +44,8 @@ public class ParentchildService {
     private final UserRepository userRepository;
     private final ParentchildRepository parentchildRepository;
     private final CalculateScore calculateScore;
+    private final FirebaseService firebaseService;
+
     private static final int RANDOM_STR_LEN = 8;
     private static final int MATCHING_SUCCESS = 2;
 
@@ -73,6 +75,9 @@ public class ParentchildService {
                         .build();
         log.info("health user="+health.getId());
         healthRepository.save(health);
+
+        // 온보딩을 마친 유저의 걸음 수 데이터 DB에 추가
+        firebaseService.insertUserStepById(userId);
 
         double exerciseScore = calculateScore.calculate(request.isExercise(), ExerciseType.of(request.exerciseType()),
                 ExerciseFrequency.of(request.exerciseCount()), ExerciseTime.of(request.exerciseTime()));

--- a/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
@@ -137,11 +137,11 @@ public class User extends BaseTimeEntity {
 	}
 
 	public void setPreUserMissionChoice(List<UserMissionChoices> userMissionChoice) {
-		log.info("임시 UserMission 선택지(매일 자정 초기화 후, 메인 홈 첫 진입 시 업데이트: {}가지", userMissionChoice.size());
-		if (!this.userMissionChoice.isEmpty()) {
-			clearPreUserMissionChoice();
+		log.info("임시 UserMission 선택지(매일 자정 초기화 후, 메인 홈 첫 진입 시 업데이트: {}가지 / User-{}가지", userMissionChoice.size(), this.userMissionChoice.size());
+		if (this.userMissionChoice.isEmpty()) {
+			this.userMissionChoice.addAll(userMissionChoice);
 		}
-		this.userMissionChoice.addAll(userMissionChoice);
+
 	}
 
 	// 가장 최근의 운동 미션 조회

--- a/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
@@ -47,4 +47,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id IN :ids")
     List<User> findAllByIds(@Param("ids") List<Long> ids);
+
+    List<User> findAllByDeleted(boolean deleted);
 }

--- a/src/main/java/sopt/org/motivooServer/global/advice/CommonExceptionType.java
+++ b/src/main/java/sopt/org/motivooServer/global/advice/CommonExceptionType.java
@@ -25,6 +25,11 @@ public enum CommonExceptionType implements BusinessExceptionType{
 	FAIL_TO_AUTHENTICATE_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "내부 인증 필터를 거치는 데 실패한 액세스 토큰입니다"),
 	TOKEN_NOT_CONTAINS_USER_ID(HttpStatus.UNAUTHORIZED, "리프레시 토큰은 유저 아이디를 담고있지 않습니다."),
 
+	/**
+	 * 500 Internal Server Error
+	 */
+	FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스와의 연결에 실패했습니다."),
+
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/sopt/org/motivooServer/global/advice/CommonExceptionType.java
+++ b/src/main/java/sopt/org/motivooServer/global/advice/CommonExceptionType.java
@@ -29,6 +29,8 @@ public enum CommonExceptionType implements BusinessExceptionType{
 	 * 500 Internal Server Error
 	 */
 	FIREBASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스와의 연결에 실패했습니다."),
+	FIREBASE_DB_INSERT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 DB에 쓰기를 수행하는 데 에러가 발생했습니다."),
+	FIREBASE_DB_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파이어베이스 DB에 읽기를 수행하는 데 에러가 발생했습니다."),
 
 	;
 

--- a/src/main/java/sopt/org/motivooServer/global/advice/ErrorType.java
+++ b/src/main/java/sopt/org/motivooServer/global/advice/ErrorType.java
@@ -27,4 +27,8 @@ public enum ErrorType {
 	public int getHttpStatusCode() {
 		return httpStatus.value();
 	}
+
+	public String message() {
+		return this.message;
+	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/org/motivooServer/global/advice/GlobalExceptionHandler.java
@@ -77,13 +77,12 @@ public class GlobalExceptionHandler {
 	 */
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(final Exception e, final HttpServletRequest request) throws
+    public ResponseEntity<ApiResponse<Exception>> handleException(final Exception e, final HttpServletRequest request) throws
 		IOException {
         slackService.sendAlert(e, request);
 
         log.error("🔔🚨 Slack에 전송된 Error Log: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(INTERNAL_SERVER_ERROR));
+        return ApiResponse.fail(INTERNAL_SERVER_ERROR, e);
     }
 
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/sopt/org/motivooServer/global/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/config/SecurityConfig.java
@@ -59,9 +59,11 @@ public class SecurityConfig {
 			@Override
 			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
-						.allowedOrigins("*")
-						.allowedOriginPatterns("*")
-						.allowedMethods("*");
+					.allowedOrigins("*")
+					.allowedOriginPatterns("*")
+					.allowedMethods("OPTIONS", "GET", "POST", "PATCH", "PUT", "DELETE")
+					.allowCredentials(true)
+					.maxAge(3600);
 			}
 		};
 	}

--- a/src/main/java/sopt/org/motivooServer/global/config/SecurityConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/config/SecurityConfig.java
@@ -61,9 +61,7 @@ public class SecurityConfig {
 				registry.addMapping("/**")
 					.allowedOrigins("*")
 					.allowedOriginPatterns("*")
-					.allowedMethods("OPTIONS", "GET", "POST", "PATCH", "PUT", "DELETE")
-					.allowCredentials(true)
-					.maxAge(3600);
+					.allowedMethods("*");
 			}
 		};
 	}

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
@@ -53,12 +53,13 @@ public class FirebaseConfig {
 			FirebaseApp.initializeApp(options);
 
 			DatabaseReference ref = FirebaseDatabase.getInstance()
-				.getReference("/public_resource");
+				.getReference("/Users");
 			ref.addListenerForSingleValueEvent(new ValueEventListener() {
 				@Override
 				public void onDataChange(DataSnapshot dataSnapshot) {
 					String res = (String)dataSnapshot.getValue();
 					System.out.println(res);
+					log.info("Firebase DB에서 받아온 데이터: {}", res);
 				}
 
 				@Override
@@ -66,6 +67,9 @@ public class FirebaseConfig {
 
 				}
 			});
+
+			log.info("파이어베이스 연결에 성공했습니다.");
+
 
 		} catch (IOException e) {
 			log.error("파이어베이스 서버와의 연결에 실패했습니다.");

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
@@ -1,7 +1,6 @@
 package sopt.org.motivooServer.global.external.firebase;
 
 import static sopt.org.motivooServer.global.advice.CommonExceptionType.*;
-import static sopt.org.motivooServer.global.advice.ErrorType.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,26 +46,12 @@ public class FirebaseConfig {
 			FirebaseOptions options = FirebaseOptions.builder()
 				.setCredentials(GoogleCredentials.fromStream(serviceAccount))
 				.setDatabaseUrl("https://"+FIREBASE_DB+".firebaseio.com")
-				.setDatabaseAuthVariableOverride(auth)
+				.setDatabaseAuthVariableOverride(null)
 				.build();
 
 			FirebaseApp.initializeApp(options);
 
-			DatabaseReference ref = FirebaseDatabase.getInstance()
-				.getReference("/Users");
-			ref.addListenerForSingleValueEvent(new ValueEventListener() {
-				@Override
-				public void onDataChange(DataSnapshot dataSnapshot) {
-					String res = (String)dataSnapshot.getValue();
-					System.out.println(res);
-					log.info("Firebase DB에서 받아온 데이터: {}", res);
-				}
-
-				@Override
-				public void onCancelled(DatabaseError error) {
-
-				}
-			});
+			// getOpponentStepCount();
 
 			log.info("파이어베이스 연결에 성공했습니다.");
 
@@ -75,5 +60,23 @@ public class FirebaseConfig {
 			log.error("파이어베이스 서버와의 연결에 실패했습니다.");
 			throw new BusinessException(FIREBASE_CONNECTION_ERROR);
 		}
+	}
+
+	public void getOpponentStepCount(Long opponentUid, Long opponentStepCount) {
+		DatabaseReference ref = FirebaseDatabase.getInstance()
+			.getReference("/Users");
+
+		ref.addListenerForSingleValueEvent(new ValueEventListener() {
+			@Override
+			public void onDataChange(DataSnapshot dataSnapshot) {
+				DataSnapshot res = dataSnapshot.child(opponentUid.toString());
+				log.info("Firebase DB에서 받아온 데이터: {}", res.getValue());
+			}
+
+			@Override
+			public void onCancelled(DatabaseError error) {
+
+			}
+		});
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseConfig.java
@@ -1,0 +1,75 @@
+package sopt.org.motivooServer.global.external.firebase;
+
+import static sopt.org.motivooServer.global.advice.CommonExceptionType.*;
+import static sopt.org.motivooServer.global.advice.ErrorType.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import sopt.org.motivooServer.global.advice.BusinessException;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+	@Value("${firebase.key.path}")
+	private String SERVICE_ACCOUNT_JSON;
+
+	@Value("${firebase.database}")
+	private String FIREBASE_DB;
+
+	@PostConstruct
+	public void init() {
+		try {
+			ClassPathResource resource = new ClassPathResource(SERVICE_ACCOUNT_JSON);
+			InputStream serviceAccount = resource.getInputStream();
+
+			Map<String, Object> auth = new HashMap<String, Object>();
+			auth.put("uid", "motivoo-user");
+
+			FirebaseOptions options = FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(serviceAccount))
+				.setDatabaseUrl("https://"+FIREBASE_DB+".firebaseio.com")
+				.setDatabaseAuthVariableOverride(auth)
+				.build();
+
+			FirebaseApp.initializeApp(options);
+
+			DatabaseReference ref = FirebaseDatabase.getInstance()
+				.getReference("/public_resource");
+			ref.addListenerForSingleValueEvent(new ValueEventListener() {
+				@Override
+				public void onDataChange(DataSnapshot dataSnapshot) {
+					String res = (String)dataSnapshot.getValue();
+					System.out.println(res);
+				}
+
+				@Override
+				public void onCancelled(DatabaseError error) {
+
+				}
+			});
+
+		} catch (IOException e) {
+			log.error("파이어베이스 서버와의 연결에 실패했습니다.");
+			throw new BusinessException(FIREBASE_CONNECTION_ERROR);
+		}
+	}
+}

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
@@ -9,15 +9,19 @@ import com.google.cloud.firestore.WriteResult;
 import com.google.firebase.cloud.FirestoreClient;
 import com.google.firebase.remoteconfig.User;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class FirebaseService {
 
-	public static final String COLLECTION_NAME = "user";
+	public static final String COLLECTION_NAME = "users";
 
-	public void insertUser() throws Exception {
+	private final FirebaseConfig firebaseConfig;
+
+	/*public void insertUser() throws Exception {
 		Firestore db = FirestoreClient.getFirestore();
 		User user = new User();
 		user.setId("4444");
@@ -25,7 +29,7 @@ public class FirebaseService {
 		ApiFuture<WriteResult> apiFuture = db.collection(COLLECTION_NAME).document("user_4").set(user);
 
 		log.info(apiFuture.get().getUpdateTime().toString());
-	}
+	}*/
 
 	public void selectUser() throws Exception {
 

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
@@ -1,0 +1,42 @@
+package sopt.org.motivooServer.global.external.firebase;
+
+import org.springframework.stereotype.Service;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.WriteResult;
+import com.google.firebase.cloud.FirestoreClient;
+import com.google.firebase.remoteconfig.User;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class FirebaseService {
+
+	public static final String COLLECTION_NAME = "user";
+
+	public void insertUser() throws Exception {
+		Firestore db = FirestoreClient.getFirestore();
+		User user = new User();
+		user.setId("4444");
+		user.setName("4444");
+		ApiFuture<WriteResult> apiFuture = db.collection(COLLECTION_NAME).document("user_4").set(user);
+
+		log.info(apiFuture.get().getUpdateTime().toString());
+	}
+
+	public void selectUser() throws Exception {
+
+		Firestore db = FirestoreClient.getFirestore();
+		User user = null;
+		ApiFuture<DocumentSnapshot> apiFuture = db.collection(COLLECTION_NAME).document("user_4").get();
+		DocumentSnapshot documentSnapshot = apiFuture.get();
+
+		if (documentSnapshot.exists()) {
+			user = documentSnapshot.toObject(User.class);
+			log.info(user.toString());
+		}
+	}
+}

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
@@ -1,15 +1,17 @@
 package sopt.org.motivooServer.global.external.firebase;
 
+import static sopt.org.motivooServer.domain.user.exception.UserExceptionType.*;
+import static sopt.org.motivooServer.global.advice.CommonExceptionType.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
-import com.google.api.core.ApiFuture;
-import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -19,7 +21,9 @@ import com.google.firebase.database.ValueEventListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.user.entity.User;
+import sopt.org.motivooServer.domain.user.exception.UserException;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
+import sopt.org.motivooServer.global.advice.BusinessException;
 
 @Slf4j
 @Service
@@ -42,35 +46,63 @@ public class FirebaseService {
 		log.info("모든 활성 유저의 데이터 insert 성공!");
 	}
 
-	public void selectUserStep() throws Exception {
+	public void insertUserStepById(Long id) {
+		final FirebaseDatabase database = FirebaseDatabase.getInstance();
+		DatabaseReference ref = database.getReference(COLLECTION_NAME);
 
+		Map<String, Integer> userSteps = new HashMap<>();
+		userSteps.put(id.toString(), 0);
+
+		ref.setValueAsync(userSteps);
+
+		log.info("새로 가입한 유저의 데이터 insert 성공!");
+	}
+
+	public void selectAllUserStep() {
 		final FirebaseDatabase database = FirebaseDatabase.getInstance();
 		DatabaseReference ref = database.getReference(COLLECTION_NAME);
 
 		readAllData(ref);
-	/*	List<String> ids = userRepository.findAllByDeleted(false).stream()
-			.map(user -> user.getId().toString())
-			.toList();
-
-		readDataByIds(ids, ref);*/
 	}
 
-	private static void readDataByIds(List<String> ids, DatabaseReference ref) {
+	public Map<String, Integer> selectUserStep(List<Long> ids) {
+		try {
+			final FirebaseDatabase database = FirebaseDatabase.getInstance();
+			DatabaseReference ref = database.getReference(COLLECTION_NAME);
+
+			return readDataByIds(ids.stream().map(Object::toString)
+				.collect(Collectors.toList()), ref);
+		} catch (InterruptedException e) {
+			throw new BusinessException(FIREBASE_DB_READ_ERROR);
+		}
+	}
+
+	public static Map<String, Integer> readDataByIds(List<String> ids, DatabaseReference ref) throws InterruptedException {
+		Map<String, Integer> result = new HashMap<>();
+		CountDownLatch latch = new CountDownLatch(ids.size());
+
 		for (String id : ids) {
 			ref.child(id).addListenerForSingleValueEvent(new ValueEventListener() {
 				@Override
 				public void onDataChange(DataSnapshot dataSnapshot) {
 					String key = dataSnapshot.getKey();
 					Object value = dataSnapshot.getValue();
-					System.out.println(key + " : " + value.toString());
+					log.info(key + " : " + value.toString());
+					result.put(key, Integer.parseInt(value.toString()));
+					latch.countDown();
 				}
 
 				@Override
 				public void onCancelled(DatabaseError databaseError) {
 					System.out.println("Failed to read value." + databaseError.toException());
+					latch.countDown();
 				}
 			});
 		}
+
+		latch.await();  // 모든 데이터를 받아올 때까지 기다립니다.
+		log.info("FB에서 가져온 Map 사이즈: {}", result.size());
+		return result;
 	}
 
 	private static void readAllData(DatabaseReference ref) {

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
@@ -1,9 +1,7 @@
 package sopt.org.motivooServer.global.external.firebase;
 
-import static sopt.org.motivooServer.domain.user.exception.UserExceptionType.*;
 import static sopt.org.motivooServer.global.advice.CommonExceptionType.*;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +18,6 @@ import com.google.firebase.database.ValueEventListener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import sopt.org.motivooServer.domain.user.entity.User;
-import sopt.org.motivooServer.domain.user.exception.UserException;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.advice.BusinessException;
 
@@ -34,8 +30,7 @@ public class FirebaseService {
 	private final UserRepository userRepository;
 
 	public void insertUserStep() {
-		final FirebaseDatabase database = FirebaseDatabase.getInstance();
-		DatabaseReference ref = database.getReference(COLLECTION_NAME);
+		DatabaseReference ref = FirebaseDatabase.getInstance().getReference(COLLECTION_NAME);
 
 		Map<String, Integer> userSteps = new HashMap<>();
 		userRepository.findAllByDeleted(false)
@@ -47,8 +42,7 @@ public class FirebaseService {
 	}
 
 	public void insertUserStepById(Long id) {
-		final FirebaseDatabase database = FirebaseDatabase.getInstance();
-		DatabaseReference ref = database.getReference(COLLECTION_NAME);
+		DatabaseReference ref = FirebaseDatabase.getInstance().getReference(COLLECTION_NAME);
 
 		Map<String, Integer> userSteps = new HashMap<>();
 		userSteps.put(id.toString(), 0);
@@ -59,16 +53,13 @@ public class FirebaseService {
 	}
 
 	public void selectAllUserStep() {
-		final FirebaseDatabase database = FirebaseDatabase.getInstance();
-		DatabaseReference ref = database.getReference(COLLECTION_NAME);
-
+		DatabaseReference ref = FirebaseDatabase.getInstance().getReference(COLLECTION_NAME);
 		readAllData(ref);
 	}
 
 	public Map<String, Integer> selectUserStep(List<Long> ids) {
 		try {
-			final FirebaseDatabase database = FirebaseDatabase.getInstance();
-			DatabaseReference ref = database.getReference(COLLECTION_NAME);
+			DatabaseReference ref = FirebaseDatabase.getInstance().getReference(COLLECTION_NAME);
 
 			return readDataByIds(ids.stream().map(Object::toString)
 				.collect(Collectors.toList()), ref);
@@ -121,5 +112,16 @@ public class FirebaseService {
 				System.out.println("Failed to read value." + databaseError.toException());
 			}
 		});
+	}
+
+	public void deleteUserStep(Long id) {
+		DatabaseReference ref = FirebaseDatabase.getInstance().getReference(COLLECTION_NAME);
+
+		Map<String, Integer> userSteps = new HashMap<>();
+		userSteps.put(id.toString(), null);  // null을 전달하면 지정된 위치에서 데이터가 삭제됨
+
+		ref.setValueAsync(userSteps);
+
+		log.info("탈퇴한 유저의 데이터 delete 성공!");
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/FirebaseService.java
@@ -1,46 +1,93 @@
 package sopt.org.motivooServer.global.external.firebase;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.DocumentSnapshot;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.WriteResult;
-import com.google.firebase.cloud.FirestoreClient;
-import com.google.firebase.remoteconfig.User;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import sopt.org.motivooServer.domain.user.entity.User;
+import sopt.org.motivooServer.domain.user.repository.UserRepository;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FirebaseService {
 
-	public static final String COLLECTION_NAME = "users";
+	public static final String COLLECTION_NAME = "Users";
+	private final UserRepository userRepository;
 
-	private final FirebaseConfig firebaseConfig;
+	public void insertUserStep() {
+		final FirebaseDatabase database = FirebaseDatabase.getInstance();
+		DatabaseReference ref = database.getReference(COLLECTION_NAME);
 
-	/*public void insertUser() throws Exception {
-		Firestore db = FirestoreClient.getFirestore();
-		User user = new User();
-		user.setId("4444");
-		user.setName("4444");
-		ApiFuture<WriteResult> apiFuture = db.collection(COLLECTION_NAME).document("user_4").set(user);
+		Map<String, Integer> userSteps = new HashMap<>();
+		userRepository.findAllByDeleted(false)
+				.forEach(user -> userSteps.put(user.getId().toString(), 0));
 
-		log.info(apiFuture.get().getUpdateTime().toString());
-	}*/
+		ref.setValueAsync(userSteps);
 
-	public void selectUser() throws Exception {
+		log.info("모든 활성 유저의 데이터 insert 성공!");
+	}
 
-		Firestore db = FirestoreClient.getFirestore();
-		User user = null;
-		ApiFuture<DocumentSnapshot> apiFuture = db.collection(COLLECTION_NAME).document("user_4").get();
-		DocumentSnapshot documentSnapshot = apiFuture.get();
+	public void selectUserStep() throws Exception {
 
-		if (documentSnapshot.exists()) {
-			user = documentSnapshot.toObject(User.class);
-			log.info(user.toString());
+		final FirebaseDatabase database = FirebaseDatabase.getInstance();
+		DatabaseReference ref = database.getReference(COLLECTION_NAME);
+
+		readAllData(ref);
+	/*	List<String> ids = userRepository.findAllByDeleted(false).stream()
+			.map(user -> user.getId().toString())
+			.toList();
+
+		readDataByIds(ids, ref);*/
+	}
+
+	private static void readDataByIds(List<String> ids, DatabaseReference ref) {
+		for (String id : ids) {
+			ref.child(id).addListenerForSingleValueEvent(new ValueEventListener() {
+				@Override
+				public void onDataChange(DataSnapshot dataSnapshot) {
+					String key = dataSnapshot.getKey();
+					Object value = dataSnapshot.getValue();
+					System.out.println(key + " : " + value.toString());
+				}
+
+				@Override
+				public void onCancelled(DatabaseError databaseError) {
+					System.out.println("Failed to read value." + databaseError.toException());
+				}
+			});
 		}
+	}
+
+	private static void readAllData(DatabaseReference ref) {
+		ref.addListenerForSingleValueEvent(new ValueEventListener() {
+			@Override
+			public void onDataChange(DataSnapshot dataSnapshot) {
+				for (DataSnapshot childSnapshot: dataSnapshot.getChildren()) {
+					String key = childSnapshot.getKey();
+					Object value = childSnapshot.getValue();
+					System.out.println(key + " : " + value.toString());
+				}
+			}
+
+			@Override
+			public void onCancelled(DatabaseError databaseError) {
+				System.out.println("Failed to read value." + databaseError.toException());
+			}
+		});
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/UserStepScheduler.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/UserStepScheduler.java
@@ -34,7 +34,7 @@ public class UserStepScheduler {
 	public void readUserStep() {
 		log.info("유저 걸음 수 읽기 연산 스케줄러 실행");
 		try {
-			firebaseService.selectUserStep();
+			firebaseService.selectAllUserStep();
 			log.info("스케줄러에서 유저 select 성공");
 		} catch (Exception e) {
 			log.error("파이어베이스 스케줄러 실행 중 발생한 에러: {}", e.getMessage());

--- a/src/main/java/sopt/org/motivooServer/global/external/firebase/UserStepScheduler.java
+++ b/src/main/java/sopt/org/motivooServer/global/external/firebase/UserStepScheduler.java
@@ -1,0 +1,44 @@
+package sopt.org.motivooServer.global.external.firebase;
+
+import static sopt.org.motivooServer.global.advice.CommonExceptionType.*;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import sopt.org.motivooServer.global.advice.BusinessException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserStepScheduler {
+
+	private final FirebaseService firebaseService;
+
+	// @Scheduled(cron = "* */2 * * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "@daily", zone = "Asia/Seoul")
+	public void flagUserStepInitialize() {
+		log.info("유저 걸음 수 초기화 스케줄러 실행");
+		try {
+			firebaseService.insertUserStep();
+			log.info("스케줄러에서 유저 insert 성공");
+			// firebaseService.selectUser();
+		} catch (Exception e) {
+			log.error("파이어베이스 스케줄러 실행 중 발생한 에러: {}", e.getMessage());
+			throw new BusinessException(FIREBASE_DB_INSERT_ERROR);
+		}
+	}
+
+	// @Scheduled(cron = "* */2 * * * *", zone = "Asia/Seoul")
+	public void readUserStep() {
+		log.info("유저 걸음 수 읽기 연산 스케줄러 실행");
+		try {
+			firebaseService.selectUserStep();
+			log.info("스케줄러에서 유저 select 성공");
+		} catch (Exception e) {
+			log.error("파이어베이스 스케줄러 실행 중 발생한 에러: {}", e.getMessage());
+			throw new BusinessException(FIREBASE_DB_READ_ERROR);
+		}
+	}
+}

--- a/src/main/java/sopt/org/motivooServer/global/response/ApiResponse.java
+++ b/src/main/java/sopt/org/motivooServer/global/response/ApiResponse.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import sopt.org.motivooServer.global.advice.BusinessExceptionType;
+import sopt.org.motivooServer.global.advice.ErrorType;
 
 @Getter
 @Builder
@@ -55,6 +56,15 @@ public class ApiResponse<T> {
 			.body(ApiResponse.<T>builder()
 				.code(exceptionType.getHttpStatusCode())
 				.message(exceptionType.message())
+				.success(false)
+				.data(data).build());
+	}
+
+	public static <T> ResponseEntity<ApiResponse<T>> fail(ErrorType errorType, T data) {
+		return ResponseEntity.status(errorType.getHttpStatus())
+			.body(ApiResponse.<T>builder()
+				.code(errorType.getHttpStatusCode())
+				.message(errorType.message())
 				.success(false)
 				.data(data).build());
 	}

--- a/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
@@ -73,10 +73,7 @@ public class HomeControllerTest extends BaseControllerTest{
 					ResourceSnippetParameters.builder()
 						.tag(TAG)
 						.description("홈 화면 조회 시 걸음 수 요청값에 대한 미션 상태 업데이트 결과 및 부모-자녀 유저의 목표 걸음 수 반환")
-						.requestFields(
-							fieldWithPath("my_step_count").type(NUMBER).description("자신의 걸음 수"),
-							fieldWithPath("opponent_step_count").type(NUMBER).description("상대 측(부모/자녀)의 걸음 수")
-						)
+						.requestFields()
 						.responseFields(
 							fieldWithPath("code").type(NUMBER).description("상태 코드"),
 							fieldWithPath("message").type(STRING).description("상태 메세지"),

--- a/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/HomeControllerTest.java
@@ -23,7 +23,6 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.mission.controller.HomeController;
-import sopt.org.motivooServer.domain.mission.dto.request.MissionStepStatusRequest;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionStepStatusResponse;
 import sopt.org.motivooServer.global.response.ApiResponse;
 
@@ -46,7 +45,6 @@ public class HomeControllerTest extends BaseControllerTest{
 	void getMissionCompleted() throws Exception {
 
 		// given
-		MissionStepStatusRequest request = new MissionStepStatusRequest(14000, 3000);
 		MissionStepStatusResponse response =  MissionStepStatusResponse.builder()
 			.userType("CHILD")
 			.userId(2L)
@@ -60,13 +58,12 @@ public class HomeControllerTest extends BaseControllerTest{
 			GET_MISSION_IMAGE_PRE_SIGNED_URL_SUCCESS, response);
 
 		// when
-		when(homeController.getMissionCompleted(request, principal)).thenReturn(result);
+		when(homeController.getMissionCompleted(principal)).thenReturn(result);
 
 		// then
 		mockMvc.perform(patch(DEFAULT_URL)
 			.contentType(MediaType.APPLICATION_JSON)
 			.accept(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(request))
 			.principal(principal)
 		).andDo(
 			document("홈 화면 미션 달성 상태 조회 API 성공 Example",


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #57 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
- Firebase Realtime DB 연동 
- 걸음 수 저장 및 조회 로직 구현
- 자정마다 걸음 수를 초기화하는 스케줄러 로직 추가
- 온보딩 입력 완료 시 FB DB에 추가
- 회원 탈퇴 시 FB DB에서 삭제

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
