### PR TITLE
[REFACTOR] 회원탈퇴 request body 삭제

### DIFF
--- a/src/main/java/sopt/org/motivooServer/domain/auth/controller/OauthController.java
+++ b/src/main/java/sopt/org/motivooServer/domain/auth/controller/OauthController.java
@@ -33,7 +33,7 @@ public class OauthController {
     @PostMapping("/oauth/reissue")
     public ResponseEntity<ApiResponse<OauthTokenResponse>> reissue(
             @RequestHeader("Authorization") String refreshToken,
-            @RequestBody final RefreshRequest request) {
+            @RequestBody RefreshRequest request) {
         return ApiResponse.success(REISSUE_SUCCESS, tokenProvider.reissue(request.userId(), refreshToken));
     }
 
@@ -45,10 +45,10 @@ public class OauthController {
     }
 
     @DeleteMapping("/withdraw")
-    public ResponseEntity<ApiResponse<Object>> signout(Principal principal,
-                                                       @Valid @RequestBody OauthTokenRequest tokenRequest) {
+    public ResponseEntity<ApiResponse<Object>> signout(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
-        userService.deleteSocialAccount(tokenRequest.tokenType(), userId, tokenRequest.accessToken());
+
+        userService.deleteSocialAccount(userId);
 
         return ApiResponse.success(SIGNOUT_SUCCESS);
     }

--- a/src/main/java/sopt/org/motivooServer/domain/auth/dto/response/OauthTokenResponse.java
+++ b/src/main/java/sopt/org/motivooServer/domain/auth/dto/response/OauthTokenResponse.java
@@ -7,6 +7,6 @@ public record OauthTokenResponse (
     String accessToken,
 
     @JsonProperty("refresh_token")
-    String refreshToke
+    String refreshToken
 ){
 }

--- a/src/main/java/sopt/org/motivooServer/domain/auth/service/OauthService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/auth/service/OauthService.java
@@ -82,8 +82,7 @@ public class OauthService {
 
         String accessToken = jwtTokenProvider.createAccessToken(String.valueOf(loginUser.getId()));
         OauthTokenResponse tokenDto = new OauthTokenResponse(accessToken, refreshToken);
-        loginUser.updateRefreshToken(tokenDto.refreshToke());
-
+        loginUser.updateRefreshToken(tokenDto.refreshToken());
 
         log.info("JWT Access Token: ", loginUser.getNickname(), tokenDto.accessToken());
         return getLoginResponse(loginUser, accessToken, refreshToken);

--- a/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/entity/User.java
@@ -115,6 +115,14 @@ public class User extends BaseTimeEntity {
 		this.refreshToken = refreshToken;
 	}
 
+	public void udpateDeleted(){
+		this.deleted = true;
+	}
+
+	public void updateDeleteAt(){
+		this.deletedAt = LocalDateTime.now().plusDays(30);
+	}
+
 	public void updateOnboardingInfo(UserType type, Integer age) {
 		this.type = type;
 		this.age = age;

--- a/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/repository/UserRepository.java
@@ -21,6 +21,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u.refreshToken from User u where u.id=?1")
     String findRefreshTokenById(Long id);
 
+    @Query("select u.socialAccessToken from User u where u.id=?1")
+    String findSocialAccessTokenById(Long id);
+
     @Query("select u from User u where u.deletedAt < now()")
     List<User> deleteExpiredUser();
 

--- a/src/main/java/sopt/org/motivooServer/domain/user/service/UserService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/user/service/UserService.java
@@ -21,7 +21,6 @@ import sopt.org.motivooServer.domain.user.entity.User;
 import sopt.org.motivooServer.domain.user.exception.UserException;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service

--- a/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
@@ -1,0 +1,97 @@
+package sopt.org.motivooServer.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import sopt.org.motivooServer.domain.auth.controller.OauthController;
+import sopt.org.motivooServer.domain.auth.dto.request.OauthTokenRequest;
+import sopt.org.motivooServer.domain.auth.dto.response.LoginResponse;
+import sopt.org.motivooServer.domain.user.repository.UserRepository;
+import sopt.org.motivooServer.global.response.ApiResponse;
+import java.security.Principal;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static java.util.TimeZone.LONG;
+import static javax.management.openmbean.SimpleType.STRING;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static sopt.org.motivooServer.global.response.SuccessType.LOGIN_SUCCESS;
+import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentRequest;
+import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentResponse;
+
+@Slf4j
+@DisplayName("OauthController 테스트")
+@WebMvcTest(OauthController.class)
+public class OauthControllerTest extends BaseControllerTest{
+    private final String TAG = "oauth";
+
+    @MockBean
+    OauthController oauthController;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    Principal principal;
+
+    @Test
+    @DisplayName("로그인 테스트")
+    void loginTest() throws Exception {
+
+        //given
+        LoginResponse response = LoginResponse.builder()
+                .id("1")
+                .nickname("모티뿌")
+                .accessToken("Bearer")
+                .accessToken("eyJ0eXAiOiJKV1QiLCJhbG")
+                .refreshToken("eyJ0eXAiOiJKV1QiLCJhbG")
+                .build();
+        ResponseEntity<ApiResponse<LoginResponse>> result = ApiResponse
+                .success(LOGIN_SUCCESS, response);
+
+        //when
+        OauthTokenRequest request = new OauthTokenRequest("eyJ0eXAiOiJKV1QiLCJhbG", "kakao");
+        when(oauthController.login(request)).thenReturn(result);
+
+        //then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/oauth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        ).andDo(
+                document("로그인 API 성공 Example",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG)
+                                        .description("소셜 로그인 API")
+                                        .requestFields(
+                                                fieldWithPath("social_access_token").type(STRING).description("access token"),
+                                                fieldWithPath("token_type").type(STRING).description("소셜 플랫폼(kakao|apple)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메세지"),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+                                                fieldWithPath("data").description("응답 데이터"),
+                                                fieldWithPath("data.id").type(LONG).description("유저 아이디"),
+                                                fieldWithPath("data.nickname").type(STRING).description("유저 닉네임"),
+                                                fieldWithPath("data.token_type").type(STRING).description("토큰 타입(Bearer)"),
+                                                fieldWithPath("data.access_token").type(STRING).description("access token"),
+                                                fieldWithPath("data.refresh_token").type(STRING).description("refresh token")
+                                        ).build()
+                        )
+                )).andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
@@ -27,15 +27,12 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import lombok.extern.slf4j.Slf4j;
 import sopt.org.motivooServer.domain.auth.controller.OauthController;
 import sopt.org.motivooServer.domain.auth.dto.request.OauthTokenRequest;
-import sopt.org.motivooServer.domain.auth.dto.request.RefreshRequest;
 import sopt.org.motivooServer.domain.auth.dto.response.LoginResponse;
-import sopt.org.motivooServer.domain.auth.dto.response.OauthTokenResponse;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.response.ApiResponse;
 
-import java.security.Principal;
 
-import static sopt.org.motivooServer.global.response.SuccessType.*;
+
 import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentRequest;
 import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentResponse;
 

--- a/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
@@ -10,14 +10,16 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import sopt.org.motivooServer.domain.auth.controller.OauthController;
 import sopt.org.motivooServer.domain.auth.dto.request.OauthTokenRequest;
+import sopt.org.motivooServer.domain.auth.dto.request.RefreshRequest;
 import sopt.org.motivooServer.domain.auth.dto.response.LoginResponse;
+import sopt.org.motivooServer.domain.auth.dto.response.OauthTokenResponse;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.response.ApiResponse;
 import java.security.Principal;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static java.util.TimeZone.LONG;
 import static javax.management.openmbean.SimpleType.STRING;
@@ -25,7 +27,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static sopt.org.motivooServer.global.response.SuccessType.LOGIN_SUCCESS;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static sopt.org.motivooServer.global.response.SuccessType.*;
 import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentRequest;
 import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentResponse;
 
@@ -92,6 +95,91 @@ public class OauthControllerTest extends BaseControllerTest{
                                                 fieldWithPath("data.refresh_token").type(STRING).description("refresh token")
                                         ).build()
                         )
-                )).andExpect(MockMvcResultMatchers.status().isOk());
+                )).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 테스트")
+    void reissueTest() throws Exception {
+        // given
+        RefreshRequest request = new RefreshRequest(1L);
+        OauthTokenResponse response = new OauthTokenResponse("eyJ0eXAiOiJKV1QiLCJhbrG", "eyJ0eXAiOiJKV1QiLCJdhbG");
+
+        log.info(response.accessToken()+" "+response.refreshToke());
+        // ApiResponse에 응답 데이터 추가
+        ResponseEntity<ApiResponse<OauthTokenResponse>> result = ApiResponse.success(REISSUE_SUCCESS, response);
+
+        // when
+        when(oauthController.reissue("eyJ0eXAiOiJKV1QiLCJhbG", request)).thenReturn(result);
+
+        // then
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/oauth/reissue")
+                .header("Authorization", "Bearer {refresh token}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        ).andDo(
+                document("토큰 재발급 API 성공 Example",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG)
+                                        .description("토큰 재발급 API")
+                                        .requestHeaders(headerWithName("Authorization")
+                                                .description("refresh token")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("user_id").type(LONG).description("유저 아이디")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메세지"),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+                                                fieldWithPath("data").description("응답 데이터"),
+                                                fieldWithPath("data.access_token").type(STRING).description("access token"),
+                                                fieldWithPath("data.refresh_token").type(STRING).description("refresh token")
+                                        ).build()
+                        )
+                )).andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 테스트")
+    void withdrawTest() throws Exception {
+
+        //given
+        OauthTokenRequest request = new OauthTokenRequest("TJ-tINCO5zPBhmFudnfm-Sjn4H3jtOe8G3IKKiWRAAABjPxmAbhDz1szkZmFRA","kakao");
+        ResponseEntity<ApiResponse<Object>> result = ApiResponse
+                .success(SIGNOUT_SUCCESS);
+
+        //when
+        when(oauthController.signout(principal, request)).thenReturn(result);
+
+        //then
+        mockMvc.perform(RestDocumentationRequestBuilders.delete("/withdraw")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(principal)
+        ).andDo(
+                document("회원탈퇴 API 성공 Example",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG)
+                                        .description("회원 탈퇴 API")
+                                        .requestFields(
+                                                fieldWithPath("social_access_token").type(STRING).description("access token"),
+                                                fieldWithPath("token_type").type(STRING).description("소셜 플랫폼(kakao|apple)")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메세지"),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부")
+                                        ).build()
+                        )
+                )).andExpect(status().isOk());
     }
 }

--- a/src/test/java/sopt/org/motivooServer/controller/ParentchildControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/ParentchildControllerTest.java
@@ -143,48 +143,50 @@ public class ParentchildControllerTest extends BaseControllerTest {
                 )).andExpect(MockMvcResultMatchers.status().isOk());
     }
 
-//    @Test
-//    @DisplayName("초대 코드 입력(매칭) 테스트")
-//    void validateInviteCode() throws Exception {
-//        //given
-//        InviteRequest request = new InviteRequest("aaaaaaaa");
-//        InviteResponse response = new InviteResponse(1L, true, false, false);
-//
-//        ResponseEntity<ApiResponse<InviteResponse>> result = ApiResponse.success(
-//                INPUT_INVITE_CODE_SUCCESS, response);
-//        //when
-//        when(parentChildController.validateInviteCode(request, principal)).thenReturn(result);
-//
-//        //then
-//        mockMvc.perform(patch("/parentchild/match")
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .accept(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(request))
-//                .principal(principal)
-//        ).andDo(
-//                document("초대 코드 입력 API 성공 Example",
-//                        getDocumentRequest(),
-//                        getDocumentResponse(),
-//                        resource(
-//                                ResourceSnippetParameters.builder()
-//                                        .tag(TAG)
-//                                        .description("초대 코드 입력 후 부모-자식 관계 매칭하는 API")
-//                                        .requestFields(
-//                                                fieldWithPath("invite_code").type(JsonFieldType.STRING).description("제공받은 초대 코드")
-//                                        )
-//                                        .responseFields(
-//                                                fieldWithPath("code").type(NUMBER).description("상태 코드"),
-//                                                fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메세지"),
-//                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
-//                                                fieldWithPath("data").description("응답 데이터"),
-//                                                fieldWithPath("data.user_id").type(LONG).description("유저 아이디"),
-//                                                fieldWithPath("data.is_matched").type(BOOLEAN).description("매칭 여부"),
-//                                                fieldWithPath("data.my_invite_code").type(BOOLEAN).description("내가 발급한 코드인지 판별"))
-//                                        .build()
-//                        )
-//                )).andExpect(MockMvcResultMatchers.status().isOk());
-//
-//    }
+    @Test
+    @DisplayName("초대 코드 입력(매칭) 테스트")
+    void validateInviteCode() throws Exception {
+        //given
+        InviteRequest request = new InviteRequest("aaaaaaaa");
+        InviteResponse response = new InviteResponse(1L, false, false, false);
+
+        ResponseEntity<ApiResponse<InviteResponse>> result = ApiResponse.success(
+                INPUT_INVITE_CODE_SUCCESS, response);
+        //when
+        when(parentChildController.validateInviteCode(request, principal)).thenReturn(result);
+
+        //then
+        mockMvc.perform(patch("/parentchild/match")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .principal(principal)
+        ).andDo(
+                document("초대 코드 입력 API 성공 Example",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(TAG)
+                                        .description("초대 코드 입력 후 부모-자식 관계 매칭하는 API")
+                                        .requestFields(
+                                                fieldWithPath("invite_code").type(JsonFieldType.STRING).description("제공받은 초대 코드")
+                                        )
+                                        .responseFields(
+                                                fieldWithPath("code").type(NUMBER).description("상태 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메세지"),
+                                                fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("응답 성공 여부"),
+                                                fieldWithPath("data").description("응답 데이터"),
+                                                fieldWithPath("data.user_id").type(LONG).description("유저 아이디"),
+                                                fieldWithPath("data.is_matched").type(BOOLEAN).description("매칭 여부"),
+                                                fieldWithPath("data.my_invite_code").type(BOOLEAN).description("내가 발급한 코드인지 판별"),
+                                                fieldWithPath("data.is_finished_onboarding").type(BOOLEAN).description("온보딩 정보했는지 여부"))
+
+                                .build()
+                        )
+                )).andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
 
     @Test
     @DisplayName("매칭 여부 확인 테스트")


### PR DESCRIPTION


## ✨ 어떤 이유로 변경된 내용인지
- 기존에는 request body에 카카오에서 발급받은 access token을 전달하도록 했었는데,
request body를 삭제하고 header에 서비스 access token만을 전달받아서 회원탈퇴를 진행하도록 수정하였습니다.
## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
