### PR TITLE
[FIX] 오늘의 미션, 미션 히스토리 API 버그 해결

### DIFF
--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/MissionHistoryResponse.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/MissionHistoryResponse.java
@@ -27,7 +27,11 @@ public record MissionHistoryResponse(
 		List<ParentchildMissionDto> parentchildMissions = new ArrayList<>(missionGroupsByDate.size());
 
 		for (Map.Entry<LocalDate, List<UserMission>> entry : missionGroupsByDate.entrySet()) {
-			parentchildMissions.add(ParentchildMissionDto.of(entry.getValue().get(0), entry.getValue().get(1)));
+			if (user.equals(entry.getValue().get(0).getUser())) {
+				parentchildMissions.add(ParentchildMissionDto.of(entry.getValue().get(0), entry.getValue().get(1)));
+			} else {
+				parentchildMissions.add(ParentchildMissionDto.of(entry.getValue().get(1), entry.getValue().get(0)));
+			}
 		}
 		return MissionHistoryResponse.builder()
 			.userType(user.getType().getValue())

--- a/src/main/java/sopt/org/motivooServer/domain/mission/exception/MissionExceptionType.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/exception/MissionExceptionType.java
@@ -25,6 +25,7 @@ public enum MissionExceptionType implements BusinessExceptionType {
 	MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미션입니다."),
 	USER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저 미션입니다."),
 	NOT_CHOICE_TODAY_MISSION(HttpStatus.NOT_FOUND, "아직 오늘의 미션을 선정하지 않았습니다."),
+	MISSION_QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 미션 퀘스트입니다."),
 
 	/**
 	 * 500 Internal Server Error

--- a/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
@@ -36,6 +36,7 @@ import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionStepStatusResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
 import sopt.org.motivooServer.domain.mission.entity.Mission;
+import sopt.org.motivooServer.domain.mission.entity.MissionQuest;
 import sopt.org.motivooServer.domain.mission.entity.MissionType;
 import sopt.org.motivooServer.domain.mission.entity.UserMission;
 import sopt.org.motivooServer.domain.mission.entity.UserMissionChoices;
@@ -360,15 +361,25 @@ public class UserMissionService {
 
 	@NotNull
 	private UserMission createTodayUserMission(Mission mission, User user) {
+		MissionQuest missionQuest = getRandomMissionQuest();
+
 		UserMission userMission = UserMission.builder()
 			.mission(mission)
-			.missionQuest(missionQuestRepository.findRandomMissionQuest())
+			.missionQuest(missionQuest)
 			.user(user)
 			.completedStatus(IN_PROGRESS).build();
 
 		userMissionRepository.save(userMission);
 		user.addUserMission(userMission);
 		return userMission;
+	}
+
+	private MissionQuest getRandomMissionQuest() {
+		MissionQuest missionQuest = missionQuestRepository.findRandomMissionQuest();
+		if (missionQuest == null) {
+			throw new MissionException(MISSION_QUEST_NOT_FOUND);
+		}
+		return missionQuest;
 	}
 
 	@NotNull

--- a/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
+++ b/src/test/java/sopt/org/motivooServer/controller/OauthControllerTest.java
@@ -3,10 +3,12 @@ package sopt.org.motivooServer.controller;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static sopt.org.motivooServer.global.response.SuccessType.*;
+import static sopt.org.motivooServer.util.ApiDocumentUtil.*;
 
 import java.security.Principal;
 
@@ -26,11 +28,6 @@ import sopt.org.motivooServer.domain.auth.dto.request.OauthTokenRequest;
 import sopt.org.motivooServer.domain.auth.dto.response.LoginResponse;
 import sopt.org.motivooServer.domain.user.repository.UserRepository;
 import sopt.org.motivooServer.global.response.ApiResponse;
-
-
-
-import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentRequest;
-import static sopt.org.motivooServer.util.ApiDocumentUtil.getDocumentResponse;
 
 @Slf4j
 @DisplayName("OauthController 테스트")
@@ -68,7 +65,7 @@ public class OauthControllerTest extends BaseControllerTest{
         when(oauthController.login(request)).thenReturn(result);
 
         //then
-        mockMvc.perform(RestDocumentationRequestBuilders.post("/oauth/login")
+        mockMvc.perform(post("/oauth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #75 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

- missionQuestRepository에서 랜덤으로 하나의 미션 퀘스트를 가져오는 메서드에서 null 여부 체크
- 운동 모아보기 뷰에서 부모-자녀 간 응답이 크로스되도록 Map 자료구조에서 다시 꺼내오기

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
