### PR TITLE
[FEAT] 상대 측의 목표 걸음 수 조회 API 구현

### DIFF
--- a/src/main/java/sopt/org/motivooServer/domain/mission/controller/UserMissionController.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/controller/UserMissionController.java
@@ -20,6 +20,7 @@ import sopt.org.motivooServer.domain.mission.dto.request.MissionImgUrlRequest;
 import sopt.org.motivooServer.domain.mission.dto.request.TodayMissionChoiceRequest;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
+import sopt.org.motivooServer.domain.mission.dto.response.OpponentGoalStepsResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
 import sopt.org.motivooServer.domain.mission.service.UserMissionService;
 import sopt.org.motivooServer.global.response.ApiResponse;
@@ -54,5 +55,10 @@ public class UserMissionController {
 		URI location = URI.create("/today" + userMissionId);
 
 		return ResponseEntity.created(location).body(ApiResponse.successV2(CHOICE_TODAY_MISSION_SUCCESS));
+	}
+
+	@GetMapping("/opponent")
+	public ResponseEntity<ApiResponse<OpponentGoalStepsResponse>> getOpponentGoalSteps(final Principal principal) {
+		return ApiResponse.success(GET_TODAY_OPPONENT_GOAL_STEP_COUNT, userMissionService.getOpponentGoalSteps(getUserFromPrincipal(principal)));
 	}
 }

--- a/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/OpponentGoalStepsResponse.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/dto/response/OpponentGoalStepsResponse.java
@@ -1,0 +1,12 @@
+package sopt.org.motivooServer.domain.mission.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OpponentGoalStepsResponse(
+	@JsonProperty("opponent_goal_step_count") int opponentGoalStepCount
+) {
+
+	public static OpponentGoalStepsResponse of(int opponentGoalStepCount) {
+		return new OpponentGoalStepsResponse(opponentGoalStepCount);
+	}
+}

--- a/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
+++ b/src/main/java/sopt/org/motivooServer/domain/mission/service/UserMissionService.java
@@ -37,6 +37,7 @@ import sopt.org.motivooServer.domain.mission.dto.request.TodayMissionChoiceReque
 import sopt.org.motivooServer.domain.mission.dto.response.MissionHistoryResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionImgUrlResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.MissionStepStatusResponse;
+import sopt.org.motivooServer.domain.mission.dto.response.OpponentGoalStepsResponse;
 import sopt.org.motivooServer.domain.mission.dto.response.TodayMissionResponse;
 import sopt.org.motivooServer.domain.mission.entity.CompletedStatus;
 import sopt.org.motivooServer.domain.mission.entity.Mission;
@@ -283,6 +284,19 @@ public class UserMissionService {
 		}
 		return MissionStepStatusResponse.of(myUser, opponentUser, 0, 0, false);*/
 
+	}
+
+	public OpponentGoalStepsResponse getOpponentGoalSteps(final Long userId) {
+		User myUser = getUserById(userId);
+		User opponentUser = getMatchedUserWith(myUser);
+
+		if (!opponentUser.getUserMissions().isEmpty()) {
+			UserMission opponentCurrentUserMission = opponentUser.getCurrentUserMission();
+			int opponentGoalStep = (opponentCurrentUserMission != null && validateTodayDateMission(opponentCurrentUserMission)) ? opponentCurrentUserMission.getMission().getStepCount() : 0;
+			assert opponentCurrentUserMission != null;
+			return OpponentGoalStepsResponse.of(opponentGoalStep);
+		}
+		throw new MissionException(NOT_EXIST_TODAY_MISSION_CHOICE);
 	}
 
 	private boolean isStepCountCompleted(int currentStepCount, UserMission todayMission) {

--- a/src/main/java/sopt/org/motivooServer/global/response/SuccessType.java
+++ b/src/main/java/sopt/org/motivooServer/global/response/SuccessType.java
@@ -22,6 +22,7 @@ public enum SuccessType {
 	//미션
 	GET_MISSION_IMAGE_PRE_SIGNED_URL_SUCCESS(HttpStatus.OK, "미션 인증사진의 Presigned Url을 생성하는 데 성공했습니다."),
 	GET_MISSION_HISTORY_SUCCESS(HttpStatus.OK, "이전 운동 미션 히스토리를 조회하는 데 성공했습니다."),
+	GET_TODAY_OPPONENT_GOAL_STEP_COUNT(HttpStatus.OK, "오늘의 상대 목표 걸음 수를 조회하는 데 성공했습니다."),
 
 	//유저
 	GET_MYINFO_SUCCESS(HttpStatus.OK, "마이페이지 나의 정보 조회에 성공했습니다."),


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #108 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
클라 측의 요청에 따라 유저 자신과 매칭된 상대 유저가 오늘의 미션을 선택한 이후 결정되는 "목표 걸음 수" 정보를 반환하는 API를 개발했습니다.

<img width="759" alt="image" src="https://github.com/Team-Motivoo/Motivoo-Server/assets/80024278/34ea6967-8088-4805-8efb-19afaa628053">


## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
