### PR TITLE
[FIX] 회원탈퇴, 오늘의 미션 선택지 관련 버그 해결

### DIFF
--- a/motivoo-api/src/main/java/sopt/org/motivoo/api/ApiApplication.java
+++ b/motivoo-api/src/main/java/sopt/org/motivoo/api/ApiApplication.java
@@ -1,10 +1,13 @@
 package sopt.org.motivoo.api;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
+import jakarta.annotation.PostConstruct;
 import sopt.org.motivoo.domain.MotivooDomainRoot;
 import sopt.org.motivoo.common.MotivooCommonRoot;
 import sopt.org.motivoo.external.MotivooExternalRoot;
@@ -19,5 +22,10 @@ public class ApiApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ApiApplication.class, args);
+	}
+
+	@PostConstruct
+	public void setTimeZone(){
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 	}
 }

--- a/motivoo-api/src/main/java/sopt/org/motivoo/api/controller/auth/OauthController.java
+++ b/motivoo-api/src/main/java/sopt/org/motivoo/api/controller/auth/OauthController.java
@@ -1,6 +1,7 @@
 package sopt.org.motivoo.api.controller.auth;
 
 import static sopt.org.motivoo.common.response.SuccessType.*;
+import static sopt.org.motivoo.domain.auth.config.jwt.JwtTokenProvider.*;
 
 import java.security.Principal;
 
@@ -53,9 +54,7 @@ public class OauthController {
 
     @DeleteMapping("/withdraw")
     public ResponseEntity<ApiResponse<Object>> signout(Principal principal) {
-        Long userId = Long.parseLong(principal.getName());
-        log.info("유저 아이디="+userId);
-        userService.deleteSocialAccount(userId);
+        oauthService.signout(getUserFromPrincipal(principal));
 
         return ApiResponse.success(SIGNOUT_SUCCESS);
     }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/auth/repository/TokenRedisRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/auth/repository/TokenRedisRetriever.java
@@ -36,6 +36,6 @@ public class TokenRedisRetriever {
 
 
     public void deleteRefreshToken(String refreshToken) {
-      tokenRedisRepository.deleteRefreshToken(refreshToken);
+        tokenRedisRepository.deleteRefreshToken(refreshToken);
     }
 }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/auth/service/OauthService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/auth/service/OauthService.java
@@ -194,16 +194,18 @@ public class OauthService {
 
         Parentchild parentchild = user.getParentchild();
         List<User> users = userRetriever.getUsersByParentchild(parentchild);
-        parentchildRetriever.deleteById(parentchild.getId());
 
         boolean allUsersDeleted = users.stream()
             .allMatch(u -> u.getSocialPlatform().equals(WITHDRAW));
+        log.info("2명의 유저 모두 탈퇴? {}", allUsersDeleted);
         if (allUsersDeleted) {
+            log.info("User Size: {}", users.size());
             if (users.size() == 1) {
                 log.info("삭제된 유저: {}", users.get(0).getNickname());
             } else if (users.size() == 2) {
                 log.info("삭제된 부모자식: {} X {}", users.get(0).getNickname(), users.get(1).getNickname());
             }
+            parentchildRetriever.deleteById(parentchild.getId());
 
             users.forEach(u -> {
                 u.getUserMissions().forEach(um -> userMissionRetriever.deleteByUser(user));

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/entity/UserMissionChoices.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/entity/UserMissionChoices.java
@@ -1,5 +1,7 @@
 package sopt.org.motivoo.domain.mission.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -39,5 +41,9 @@ public class UserMissionChoices extends BaseTimeEntity {
 	public UserMissionChoices(Mission mission, User user) {
 		this.mission = mission;
 		this.user = user;
+	}
+
+	public void setCreatedAtNow(LocalDateTime dateTime) {
+		this.createdAt = dateTime;
 	}
 }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionChoicesRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionChoicesRepository.java
@@ -11,7 +11,7 @@ import sopt.org.motivoo.domain.user.entity.User;
 
 public interface UserMissionChoicesRepository extends JpaRepository<UserMissionChoices, Long> {
 
-    void deleteByUser(User user);
+    void deleteAllByUser(User user);
 
     @Query("SELECT umc FROM UserMissionChoices umc WHERE umc.user = :user AND DATE(umc.createdAt) = DATE(:date)")
     List<UserMissionChoices> findAllByUserAndCreatedAt(User user, LocalDate date);

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionChoicesRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionChoicesRetriever.java
@@ -31,7 +31,7 @@ public class UserMissionChoicesRetriever {
 	}
 
 	public void deleteByUser(User user) {
-		userMissionChoicesRepository.deleteByUser(user);
+		userMissionChoicesRepository.deleteAllByUser(user);
 	}
 
 	public List<UserMissionChoices> getUserMissionChoice(User user) {

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
@@ -34,7 +34,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
 
 	//== DELETE ==//
-	void deleteByUser(User user);
+	void deleteAllByUser(User user);
 
 
 	//== UPDATE ==//

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import sopt.org.motivoo.domain.mission.entity.CompletedStatus;
 import sopt.org.motivoo.domain.mission.entity.Mission;
 import sopt.org.motivoo.domain.mission.entity.MissionQuest;
 import sopt.org.motivoo.domain.mission.entity.UserMission;
@@ -38,7 +39,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
 	//== UPDATE ==//
 	@Modifying
-	@Query("UPDATE UserMission um SET um.mission = :mission, um.missionQuest = :quest WHERE um.user = :user AND DATE(um.createdAt) = DATE(:date)")
-	void updateValidTodayMission(Mission mission, MissionQuest quest, User user, LocalDate date);
+	@Query("UPDATE UserMission um SET um.mission = :mission, um.missionQuest = :quest, um.completedStatus = :status WHERE um.user = :user AND DATE(um.createdAt) = DATE(:date)")
+	void updateValidTodayMission(Mission mission, MissionQuest quest, CompletedStatus status, User user, LocalDate date);
 }
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
@@ -1,5 +1,6 @@
 package sopt.org.motivoo.domain.mission.repository;
 
+import static sopt.org.motivoo.domain.mission.entity.CompletedStatus.*;
 import static sopt.org.motivoo.domain.mission.exception.MissionExceptionType.*;
 
 import java.time.LocalDate;
@@ -47,7 +48,7 @@ public class UserMissionRetriever {
 
 	//== UPDATE ==//
 	public void updateUserMission(User user, Mission mission, MissionQuest quest) {
-		userMissionRepository.updateValidTodayMission(mission, quest, user, LocalDate.now());
+		userMissionRepository.updateValidTodayMission(mission, quest, IN_PROGRESS, user, LocalDate.now());
 	}
 
 	//== CREATE ==//

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
@@ -43,7 +43,7 @@ public class UserMissionRetriever {
 
 	//== DELETE ==//
 	public void deleteByUser(User user) {
-		userMissionRepository.deleteByUser(user);
+		userMissionRepository.deleteAllByUser(user);
 	}
 
 	//== UPDATE ==//

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
@@ -3,9 +3,9 @@ package sopt.org.motivoo.domain.mission.service;
 import static sopt.org.motivoo.domain.mission.entity.CompletedStatus.*;
 import static sopt.org.motivoo.domain.mission.exception.MissionExceptionType.*;
 import static sopt.org.motivoo.domain.user.exception.UserExceptionType.*;
-import static sopt.org.motivoo.external.s3.S3BucketDirectory.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -141,6 +141,7 @@ public class UserMissionManager {
 			UserMissionChoices missionChoice = UserMissionChoices.builder()
 				.mission(missionChoicesFiltered.get(i))
 				.user(user).build();
+			missionChoice.setCreatedAtNow(LocalDateTime.now());
 			missionChoices.add(missionChoice);
 		}
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
@@ -293,7 +293,7 @@ public class UserMissionManager {
 	// 매칭된 유저의 탈퇴 여부 검사
 	public static void checkMatchedUserWithdraw(User opponentUser) {
 		if (opponentUser.isDeleted()) {
-			throw new UserException(ALREADY_WITHDRAW_USER);
+			throw new UserException(ALREADY_WITHDRAW_OPPONENT_USER);
 		}
 	}
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
@@ -125,7 +125,6 @@ public class UserMissionService {
 		MissionQuest missionQuest = missionQuestRetriever.getRandomMissionQuest();
 		userMissionRetriever.updateUserMission(user, mission, missionQuest);
 		UserMission todayMission = user.getCurrentUserMission();
-		todayMission.updateCompletedStatus(IN_PROGRESS);
 		return todayMission.getId();
 	}
 
@@ -188,7 +187,8 @@ public class UserMissionService {
 		 */
 		boolean existsUserMission = userMissionRetriever.existsByUser(user);
 		boolean isFiltered = userMissionChoicesRetriever.existsByUser(user);
-		log.info("User {}의 UserMission이 비어있니? {} ", user.getNickname(), existsUserMission);
+		log.info("User {}의 UserMission이 존재하니? {} ", user.getNickname(), existsUserMission);
+		log.info("오늘의 미션 선택지 필터링을 거쳤니? {} ", isFiltered);
 
 		// 1) 처음 가입한 유저의 경우 -> 미션 선택지 세팅 완료
 		if (!existsUserMission) {
@@ -201,6 +201,7 @@ public class UserMissionService {
 
 		// 2) 필터링 로직을 한 번 이상 거친 경우 -> 저장된 미션 선택지 가져오기
 		if (isFiltered && todayMission.isEmptyUserMission()) {
+			log.info("2. 필터링 로직을 한 번 이상 거친 경우");
 			List<UserMissionChoices> missionChoice = userMissionChoicesRetriever.getUserMissionChoice(user);
 			return TodayMissionResult.of(missionChoice);
 		}
@@ -210,7 +211,7 @@ public class UserMissionService {
 
 		// 3) 일반적인 경우 - 마션 선택지 필터링
 		if (todayMission.isNowDate() && todayMission.isEmptyUserMission()) {
-			log.info("필터링 GO");
+			log.info("일반적인 경우(미션 선택지 필터링 이전)");
 			return getMissionChoicesResult(user);
 		}
 		// 3-1) TODO DB 초기화 하고 삭제해도 됨!
@@ -232,6 +233,7 @@ public class UserMissionService {
 
 		List<UserMissionChoices> todayMissionChoices = filterTodayUserMission(user);
 		log.info("첫 가입 유저 오늘의 미션 선택지 세팅 완료! : {}", todayMissionChoices.size());
+		user.addTodayUserMissionChoice(todayMissionChoices);
 		return TodayMissionResult.of(todayMissionChoices);
 	}
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
@@ -192,7 +192,7 @@ public class UserMissionService {
 
 		// 1) 처음 가입한 유저의 경우 -> 미션 선택지 세팅 완료
 		if (!existsUserMission) {
-			log.info("첫 가입 유저 미션 필터링 진입");
+			log.info("1. 첫 가입 유저 미션 필터링 진입");
 			createEmptyMission(List.of(user, opponentUser));
 			return getMissionChoicesResult(user);
 		}
@@ -211,12 +211,7 @@ public class UserMissionService {
 
 		// 3) 일반적인 경우 - 마션 선택지 필터링
 		if (todayMission.isNowDate() && todayMission.isEmptyUserMission()) {
-			log.info("일반적인 경우(미션 선택지 필터링 이전)");
-			return getMissionChoicesResult(user);
-		}
-		// 3-1) TODO DB 초기화 하고 삭제해도 됨!
-		if (!validateTodayDateMission(todayMission)) {
-			createEmptyMission(List.of(user, opponentUser));
+			log.info("3. 일반적인 경우(미션 선택지 필터링 이전)");
 			return getMissionChoicesResult(user);
 		}
 
@@ -255,7 +250,7 @@ public class UserMissionService {
 		MissionQuest missionQuest = missionQuestRetriever.getRandomMissionQuest();
 
 		List<User> filteredUsers = users.stream()
-			.filter(user -> !user.getUserMissions().isEmpty() && !user.getCurrentUserMission().isNowDate())
+			.filter(user -> user.getUserMissions().isEmpty() || (!user.getUserMissions().isEmpty() && !user.getCurrentUserMission().isNowDate()))
 			.toList();
 		userMissionRetriever.bulkSaveInitUserMission(filteredUsers, LocalDate.now(), emptyMission, missionQuest);
 	}

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/repository/ParentchildRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/repository/ParentchildRepository.java
@@ -10,6 +10,4 @@ import sopt.org.motivoo.domain.parentchild.entity.Parentchild;
 
 public interface ParentchildRepository extends JpaRepository<Parentchild, Long> {
     Optional<Parentchild> findByInviteCode(String inviteCode);
-    void deleteById(Long id);
-
 }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/service/ParentchildService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/service/ParentchildService.java
@@ -82,18 +82,18 @@ public class ParentchildService {
         checkOnboardingCompleted(user);
 
         Parentchild parentchild = parentchildRetriever.getByInviteCode(request.inviteCode());
+        int count = userRetriever.getParentchildUserCnt(parentchild);
+        if (count == 1) {
+            // validateInviteRequest(user, parentchild);
+            completeMatching(user, parentchild);
+        }
         Long opponentUserId = userRetriever.getOpponentUserId(userId);
         log.info("매칭된 상대 유저의 ID: {}", opponentUserId);
 
         if (parentchild.isMatched()) {
             return new InviteReceiveResult(userId, opponentUserId, true);
         }
-        if (user.getParentchild() != null) {
-            validateInviteRequest(user, parentchild);
-        }
-
         validateInviteRequest(user, parentchild);
-        completeMatching(user, parentchild);
 
         return new InviteReceiveResult(userId, opponentUserId, true);
     }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/service/ParentchildService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/service/ParentchildService.java
@@ -49,7 +49,7 @@ public class ParentchildService {
 
         User user = userRetriever.getUserById(userId);
         Health health = parentchildManager.onboardInput(user, request);
-        // healthRetriever.validateHealthByUser(user);   // TODO API 중복 호출 예외처리
+        healthRetriever.validateHealthByUser(user);   // TODO API 중복 호출 예외처리
         healthRetriever.save(health);
 
         // Slack 신규 유저 알림 전송

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/entity/User.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/entity/User.java
@@ -79,8 +79,8 @@ public class User extends BaseTimeEntity {
 	@OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
 	private final List<UserMission> userMissions = new ArrayList<>();
 
-	// @OneToMany(fetch = FetchType.EAGER)
-	// private final List<UserMissionChoices> userMissionChoice = new ArrayList<>();
+	@OneToMany(mappedBy = "user", fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+	private final List<UserMissionChoices> userMissionChoice = new ArrayList<>();
 
 	@Builder
 	private User(String nickname, String socialId, SocialPlatform socialPlatform, String socialAccessToken,
@@ -149,13 +149,10 @@ public class User extends BaseTimeEntity {
 	// 	this.userMissionChoice.clear();
 	// }
 
-	// public void setPreUserMissionChoice(List<UserMissionChoices> userMissionChoice) {
-	// 	log.info("임시 UserMission 선택지(매일 자정 초기화 후, 메인 홈 첫 진입 시 업데이트: {}가지 / User-{}가지", userMissionChoice.size(), this.userMissionChoice.size());
-	// 	if (this.userMissionChoice.isEmpty()) {
-	// 		this.userMissionChoice.addAll(userMissionChoice);
-	// 	}
-	//
-	// }
+	public void addTodayUserMissionChoice(List<UserMissionChoices> userMissionChoice) {
+		log.info("UserMission 선택지(매일 자정 초기화 후, 메인 홈 첫 진입 시 업데이트: {}가지 / User-{}가지", userMissionChoice.size(), this.userMissionChoice.size());
+		this.userMissionChoice.addAll(userMissionChoice);
+	}
 
 	// 가장 최근의 운동 미션 조회
 	public UserMission getCurrentUserMission() {

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/exception/UserExceptionType.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/exception/UserExceptionType.java
@@ -17,6 +17,7 @@ public enum UserExceptionType implements BusinessExceptionType {
 	NULL_VALUE_USERTYPE_ENUM(HttpStatus.BAD_REQUEST, "데이터베이스의 유저 타입이 유효하지 않은 값입니다."),
 	NULL_VALUE_AGE(HttpStatus.BAD_REQUEST, "유저의 나이는 null이어서는 안 됩니다."),
 	ALREADY_WITHDRAW_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 유저입니다."),
+	ALREADY_WITHDRAW_OPPONENT_USER(HttpStatus.BAD_REQUEST, "상대 유저가 탈퇴하여 요청을 처리할 수 없습니다."),
 
 	/**
 	 * 401 Unauthorized
@@ -32,6 +33,10 @@ public enum UserExceptionType implements BusinessExceptionType {
 	 */
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
 
+	/**
+	 * 412 Precondition Failed
+	 */
+	// ALREADY_WITHDRAW_OPPONENT_USER(HttpStatus.PRECONDITION_FAILED, "상대 유저가 탈퇴하여 요청을 처리할 수 없습니다."),
 
 	;
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRepository.java
@@ -42,8 +42,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.parentchild = ?1 and u.deleted=false")
     List<User> findUserByParentchild(Parentchild parentchild);
 
-    @Query("select u from User u where u.parentchild.id = ?1 and u.deleted=false")
-    List<User> findUsersByParentchildId(Long parentchildId);
+    @Query("select u from User u where u.parentchild = ?1 and u.deleted=false")
+    List<User> findUsersByParentchild(Parentchild parentchild);
 
     @Query("select u from User u where u.id!=?1 and u.parentchild=?2")
     Optional<User> findByIdAndParentchild(Long userId, Parentchild parentchild);

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRepository.java
@@ -39,10 +39,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select u from User u where u.parentchild = ?1 and u.deleted=true")
     List<User> findByParentchild(Parentchild parentchild);
 
-    @Query("select u from User u where u.parentchild = ?1 and u.deleted=false")
-    List<User> findUserByParentchild(Parentchild parentchild);
-
-    @Query("select u from User u where u.parentchild = ?1 and u.deleted=false")
     List<User> findUsersByParentchild(Parentchild parentchild);
 
     @Query("select u from User u where u.id!=?1 and u.parentchild=?2")

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/repository/UserRetriever.java
@@ -53,8 +53,8 @@ public class UserRetriever {
 			() -> new ParentchildException(NOT_EXIST_PARENTCHILD_USER));
 	}
 
-	public List<User> getUsersByParentchildId(Long parentchildId) {
-		return userRepository.findUsersByParentchildId(parentchildId);
+	public List<User> getUsersByParentchild(Parentchild parentchild) {
+		return userRepository.findUsersByParentchild(parentchild);
 	}
 
 	public List<User> getAllByParentchild(Parentchild parentchild) {

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/service/UserManager.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/service/UserManager.java
@@ -34,4 +34,14 @@ public class UserManager {
 
 		//sendRevokeRequest(null, KAKAO, "FHdk_lLY2GObLpez2qGCdmqDlMBwwDk7FXgKPXTZAAABjRVYY2X6Fwx8Dt1GgQ"); //카카오 연결 해제
 	}
+
+	@Transactional
+	public void withdrawUser(User user) {
+
+		user.updateRefreshToken(null);
+		user.deleteSocialInfo();
+		user.updateDeleted();
+		user.updateDeleteAt();
+		//sendRevokeRequest(null, KAKAO, "FHdk_lLY2GObLpez2qGCdmqDlMBwwDk7FXgKPXTZAAABjRVYY2X6Fwx8Dt1GgQ"); //카카오 연결 해제
+	}
 }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/service/UserService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/service/UserService.java
@@ -30,9 +30,6 @@ public class UserService {
 
 	private final UserRetriever userRetriever;
 	private final HealthRetriever healthRetriever;
-	private final TokenRedisRepository tokenRedisRepository;
-
-	private final UserManager userManager;
 
 	public MyPageInfoResult getMyInfo(final Long userId) {
 		User user = userRetriever.getUserById(userId);
@@ -42,49 +39,6 @@ public class UserService {
 	public MyHealthInfoResult getMyHealthInfo(final Long userId) {
 		Health health = healthRetriever.getHealthByUserId(userId);
 		return MyHealthInfoResult.of(health);
-	}
-
-
-	@Transactional
-	public void deleteSocialAccount(Long userId) {
-
-		User user = userRetriever.getUserById(userId);
-		List<User> sameSocialUsers = userRetriever.getUsersBySocialId(user.getSocialId());  // 동일한 소셜 계정으로 탈퇴-가입을 반복한 경우
-		userManager.deleteKakaoAccount(sameSocialUsers);
-		healthRetriever.deleteByUser(user);   // 온보딩 건강 정보 삭제
-
-		//TODO 애플 로그인 구현 후 리팩토링
-/*		switch (){
-			case "apple" ->
-			case "kakao" -> deleteKakaoAccount(userId, accessToken);
-		}*/
-	}
-
-
-	// TODO 혜연 언니한테 질문
-	private void sendRevokeRequest(String data, SocialPlatform socialPlatform, String accessToken) {
-		// String appleRevokeUrl = "https://appleid.apple.com/auth/revoke"; //TODO 추후 애플 로그인 구현 후
-		String kakaoRevokeUrl = "https://kapi.kakao.com/v1/user/unlink";
-
-		RestTemplate restTemplate = new RestTemplate();
-		String revokeUrl = "";
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-		HttpEntity<String> entity = new HttpEntity<>(data, headers);
-
-		switch (socialPlatform) {
-			// case APPLE -> revokeUrl = appleRevokeUrl;
-			case KAKAO -> {
-				revokeUrl = kakaoRevokeUrl;
-				headers.setBearerAuth(accessToken);
-			}
-		}
-
-		ResponseEntity<String> responseEntity = restTemplate.exchange(revokeUrl, HttpMethod.POST, entity, String.class);
-
-		log.info("response="+responseEntity);
 	}
 
 }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #126

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
### Timezone 불일치 문제 해결
객체 생성 시의 createdAt, updatedAt 필드가 Asia/Seoul 기준의 Timezone으로 적용되지 않는 문제를 해결했습니다.
- 서버 메인 어플리케이션 실행 시 timezone 세팅
- RDS DB의 default timezone 'Asia/Seoul'로 세팅

### 회원탈퇴 로직 개선
- 회원탈퇴 시 소셜 플랫폼에 상관없이 소셜 정보가 삭제되도록 수정
- RefreshToken을 Redis에서 삭제하도록 추가
- 탈퇴 시, 미션 선택지 모두 삭제
- Parentchild에 종속된 2명의 유저가 모두 삭제되는 경우, UserMission, Parentchild 삭제

### 오늘의 미션 선택지 관련 버그 해결
처음 가입한 유저의 경우, 제대로 emptyMission이 저장되지 않는 문제를 해결했습니다
- 필터링 조건 추가

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
- 클라분들 답변에 따라 상대 유저가 탈퇴한 경우의 HTTP 상태코드를 400 Bad Request (기존) -> 412 Precondition Failed (변경)으로 바꿀 예정입니다! 참고해주세요 ~