### PR TITLE
[FIX] UserMission 업데이트 쿼리에서의 비관적 락 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ motivoo-firebase-adminsdk.json
 **.http
 
 **.sql
+logback-**.xml
 
 local.properties
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/entity/UserMission.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/entity/UserMission.java
@@ -120,6 +120,10 @@ public class UserMission extends BaseTimeEntity {
 		this.updateCompletedStatus(IN_PROGRESS);
 	}
 
+	public void updateMissionQuest(MissionQuest missionQuest) {
+		this.missionQuest = missionQuest;
+	}
+
 	public boolean isEmptyUserMission() {
 		return this.getMission().getTarget().equals(UserType.NONE);
 	}

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRepository.java
@@ -39,7 +39,7 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
 
 	//== UPDATE ==//
 	@Modifying
-	@Query("UPDATE UserMission um SET um.mission = :mission, um.missionQuest = :quest, um.completedStatus = :status WHERE um.user = :user AND DATE(um.createdAt) = DATE(:date)")
-	void updateValidTodayMission(Mission mission, MissionQuest quest, CompletedStatus status, User user, LocalDate date);
+	@Query("UPDATE UserMission um SET um.mission = :mission, um.missionQuest = :quest WHERE um.user = :user AND DATE(um.createdAt) = DATE(:date)")
+	void updateValidTodayMission(Mission mission, MissionQuest quest, User user, LocalDate date);
 }
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/repository/UserMissionRetriever.java
@@ -52,7 +52,7 @@ public class UserMissionRetriever {
 
 	//== UPDATE ==//
 	public void updateUserMission(User user, Mission mission, MissionQuest quest) {
-		userMissionRepository.updateValidTodayMission(mission, quest, IN_PROGRESS, user, LocalDate.now());
+		userMissionRepository.updateValidTodayMission(mission, quest, user, LocalDate.now());
 	}
 
 	//== CREATE ==//

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionManager.java
@@ -172,6 +172,12 @@ public class UserMissionManager {
 		return missionChoices;
 	}
 
+	public static void setTodayMission(UserMission todayMission, Mission mission, MissionQuest missionQuest) {
+		todayMission.updateMissionFromEmpty(mission);
+		todayMission.updateCompletedStatus(CompletedStatus.IN_PROGRESS);
+		todayMission.updateMissionQuest(missionQuest);
+	}
+
 	@NotNull
 	public UserMission createEmptyUserMission(User user, LocalDate date, Mission mission, MissionQuest quest) {
 		UserMission um = UserMission.builderForEmpty()

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/mission/service/UserMissionService.java
@@ -121,8 +121,9 @@ public class UserMissionService {
 		}
 
 		MissionQuest missionQuest = missionQuestRetriever.getRandomMissionQuest();
-		userMissionRetriever.updateUserMission(user, mission, missionQuest);
+		// userMissionRetriever.updateUserMission(user, mission, missionQuest);
 		UserMission todayMission = user.getCurrentUserMission();
+		setTodayMission(todayMission, mission, missionQuest);
 		return todayMission.getId();
 	}
 

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/entity/Parentchild.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/parentchild/entity/Parentchild.java
@@ -1,5 +1,7 @@
 package sopt.org.motivoo.domain.parentchild.entity;
 
+import static sopt.org.motivoo.domain.parentchild.exception.ParentchildExceptionType.*;
+
 import java.util.List;
 
 import jakarta.persistence.Column;
@@ -12,6 +14,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.org.motivoo.domain.common.BaseTimeEntity;
+import sopt.org.motivoo.domain.parentchild.exception.ParentchildException;
+import sopt.org.motivoo.domain.parentchild.exception.ParentchildExceptionType;
 import sopt.org.motivoo.domain.user.entity.User;
 
 @Getter
@@ -43,10 +47,9 @@ public class Parentchild extends BaseTimeEntity {
 	public boolean validateParentchild(int userCnt) {
 
 		// 부모자식 관계에 대한 예외처리
-		if (userCnt != 2) {
-			return false;
+		if (userCnt >= 3) {
+			throw new ParentchildException(INVALID_PARENTCHILD_RELATION);
 		}
-
-		return true;
+		return userCnt == 2 && isMatched;
 	}
 }

--- a/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/exception/UserExceptionType.java
+++ b/motivoo-domain/src/main/java/sopt/org/motivoo/domain/user/exception/UserExceptionType.java
@@ -17,7 +17,6 @@ public enum UserExceptionType implements BusinessExceptionType {
 	NULL_VALUE_USERTYPE_ENUM(HttpStatus.BAD_REQUEST, "데이터베이스의 유저 타입이 유효하지 않은 값입니다."),
 	NULL_VALUE_AGE(HttpStatus.BAD_REQUEST, "유저의 나이는 null이어서는 안 됩니다."),
 	ALREADY_WITHDRAW_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 유저입니다."),
-	ALREADY_WITHDRAW_OPPONENT_USER(HttpStatus.BAD_REQUEST, "상대 유저가 탈퇴하여 요청을 처리할 수 없습니다."),
 
 	/**
 	 * 401 Unauthorized
@@ -36,7 +35,7 @@ public enum UserExceptionType implements BusinessExceptionType {
 	/**
 	 * 412 Precondition Failed
 	 */
-	// ALREADY_WITHDRAW_OPPONENT_USER(HttpStatus.PRECONDITION_FAILED, "상대 유저가 탈퇴하여 요청을 처리할 수 없습니다."),
+	ALREADY_WITHDRAW_OPPONENT_USER(HttpStatus.PRECONDITION_FAILED, "상대 유저가 탈퇴하여 요청을 처리할 수 없습니다."),
 
 	;
 


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] : 기능 추가
- [FIX] : 에러 수정, 버그 수정
- [CHORE] : gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] : README, 문서
- [REFACTOR] : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] : 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #133 

## ✨ 어떤 이유로 변경된 내용인지
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

- UserMission의 mission_id와 completed_status 를 업데이트 하는 jpql 쿼리에서 동시성 문제에 의한 비관적 락이 걸리는 문제를 해결하고자 함
-  업데이트 쿼리 호출 횟수에 따라 version을 명시하거나, 비관적 락 -> 낙관적 락으로 변경하는 등의 방안을 떠올렸으나, 현재는 객체 그래프 탐색으로 대체해둔 상태  *추후 논의점
- 온보딩 매칭 API 에서 초대를 수신하는 측의 필터링 조건 추가

## 🙏 검토 혹은 리뷰어에게 남기고 싶은 말
